### PR TITLE
image helpers: add missing import

### DIFF
--- a/cli/templates/project/src/styles/helpers/_helpers-images.scss
+++ b/cli/templates/project/src/styles/helpers/_helpers-images.scss
@@ -1,3 +1,5 @@
+@use "./helpers-math" as *;
+
 // Responsively positions a child element relative to its parent container.
 // Expects unitless values as input.
 @mixin image-positioning($top, $left, $width, $containerWidth, $containerHeight) {


### PR DESCRIPTION
Image helpers referenced an undefined SASS function `percent-ratio-css-vars`. Fixed by importing `helpers-math.scss`