### PR TITLE
fix bin name

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "bin/index.js",
   "bin": {
-    "corgiTest": "bin/index.js"
+    "corgi": "bin/index.js"
   },
   "author": "Andrew Rubin <andrew@wethecollective.com> (https://wethecollective.com/)",
   "contributors": [],


### PR DESCRIPTION
the command name was `corgiTest`, should be `corgi`. This would have broken any usage of the `corgi` command when using a global install.