### PR TITLE
Bugfix: CLI: project template gitignore is ignored by NPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,7 @@
-# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
-
 # dependencies
 node_modules
 /.pnp
 .pnp.js
-
-# testing
-/coverage
-
-# next.js
-.next/
-out/
-public/sitemap.xml
-public/sitemap-0.xml
-public/robots.txt
-
-# production
-build
-dist
-deploy
 
 # misc
 .DS_Store
@@ -28,12 +11,3 @@ deploy
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
-# local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
-
-# vercel
-.vercel

--- a/cli/.npmignore
+++ b/cli/.npmignore
@@ -1,0 +1,16 @@
+# This file contains all the default items in an .npmignore,
+# minus the .gitignore, since we need that in our template.
+
+.*.swp
+._*
+.DS_Store
+.git
+.hg
+.npmignore
+.npmrc
+.lock-wscript
+.svn
+.wafpickle-*
+config.gypi
+CVS
+npm-debug.log

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/corgi",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Command line interface for use with the corgi framework.",
   "type": "module",
   "main": "bin/index.js",

--- a/cli/templates/project/.gitignore
+++ b/cli/templates/project/.gitignore
@@ -1,22 +1,17 @@
-# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
-
 # dependencies
-/node_modules
-/.pnp
+node_modules
+.pnp
 .pnp.js
 
-# testing
-/coverage
-
 # next.js
-/.next/
-/out/
-/public/sitemap.xml
-/public/sitemap-0.xml
-/public/robots.txt
+.next
+out
+public/sitemap.xml
+public/sitemap-0.xml
+public/robots.txt
 
 # production
-/build
+build
 
 # misc
 .DS_Store
@@ -32,6 +27,3 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
-
-# vercel
-.vercel

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
     },
     "cli": {
       "name": "@wethegit/corgi",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "MIT",
       "dependencies": {
         "chalk": "~5.0.1",


### PR DESCRIPTION
This adds an explicit `.npmignore` which does _not_ include `.gitignore`. This is so that we have a gitignore when bootstrapping a new project.