### PR TITLE
Feature/webpack-resolvers

### DIFF
--- a/cli/templates/component/component.js
+++ b/cli/templates/component/component.js
@@ -1,4 +1,4 @@
-//packages
+// packages
 import { useEffect, useState } from "react"
 
 // components

--- a/cli/templates/component/component.js
+++ b/cli/templates/component/component.js
@@ -4,10 +4,10 @@ import { useEffect, useState } from "react"
 // components
 
 // hooks
-import useLocale from "#hooks/use-locale"
+import useLocale from "@local/hooks/use-locale"
 
 // utilities
-import classnames from "#utils/classnames"
+import classnames from "@local/utils/classnames"
 
 // styles
 import * as styles from "./COMPONENT_SLUG.module.scss"

--- a/cli/templates/page.js
+++ b/cli/templates/page.js
@@ -1,6 +1,6 @@
-import { setupPaths, setupProps } from "#utils/page-setup"
-import PageProvider from "#context/page-context"
-import useLocale from "#hooks/use-locale"
+import { setupPaths, setupProps } from "@local/utils/page-setup"
+import PageProvider from "@local/context/page-context"
+import useLocale from "@local/hooks/use-locale"
 
 const LOCALE_FOLDER = "PAGE_SLUG"
 

--- a/cli/templates/project/next.config.js
+++ b/cli/templates/project/next.config.js
@@ -14,6 +14,7 @@ const nextConfig = {
       "@local/context": resolve("src/context"),
       "@local/hooks": resolve("src/hooks"),
       "@local/utils": resolve("src/utils"),
+      "@local/styles": resolve("src/styles"),
     }
     return config
   },

--- a/cli/templates/project/next.config.js
+++ b/cli/templates/project/next.config.js
@@ -1,9 +1,22 @@
+const path = require("path")
 const withPlugins = require("next-compose-plugins")
 const yaml = require("next-plugin-yaml")
+
+const resolve = (dirPath) => path.resolve(__dirname, dirPath)
 
 const nextConfig = {
   reactStrictMode: true,
   trailingSlash: true,
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@local/components": resolve("src/components"),
+      "@local/context": resolve("src/context"),
+      "@local/hooks": resolve("src/hooks"),
+      "@local/utils": resolve("src/utils"),
+    }
+    return config
+  },
 }
 
 module.exports = withPlugins([[yaml], nextConfig])

--- a/cli/templates/project/package.json
+++ b/cli/templates/project/package.json
@@ -12,12 +12,6 @@
     "preflight": "npm run mash-build-all && next build",
     "start": "npm run mash-watch & next dev -p 8080"
   },
-  "imports": {
-    "#components/*": "./src/components/*.js",
-    "#context/*": "./src/context/*.js",
-    "#hooks/*": "./src/hooks/*.js",
-    "#utils/*": "./src/utils/*.js"
-  },
   "dependencies": {
     "@wethegit/react-hooks": "^0.0.5",
     "next": "~12.1.0",

--- a/cli/templates/project/src/components/app-context-providers.js
+++ b/cli/templates/project/src/components/app-context-providers.js
@@ -1,7 +1,7 @@
 import { UserPreferencesProvider } from "@wethegit/react-hooks";
 
-import LocaleProvider from "#context/locale-context";
-import SiteStateProvider from "#context/site-state-context";
+import LocaleProvider from "@local/context/locale-context";
+import SiteStateProvider from "@local/context/site-state-context";
 
 const AppContextProviders = ({ children, localeData, ...pageProps }) => {
   return (

--- a/cli/templates/project/src/components/body-scripts.js
+++ b/cli/templates/project/src/components/body-scripts.js
@@ -5,7 +5,7 @@
  */
 
 import Script from "next/script"
-import useLocale from "#hooks/use-locale"
+import useLocale from "@local/hooks/use-locale"
 
 const BodyScripts = ({}) => {
   const { globals, page } = useLocale()

--- a/cli/templates/project/src/components/footer/footer.js
+++ b/cli/templates/project/src/components/footer/footer.js
@@ -1,4 +1,4 @@
-import useLocale from "#hooks/use-locale"
+import useLocale from "@local/hooks/use-locale"
 
 import { footer } from "./footer.module.scss"
 

--- a/cli/templates/project/src/components/home-page-contents/home-page-contents.js
+++ b/cli/templates/project/src/components/home-page-contents/home-page-contents.js
@@ -1,4 +1,4 @@
-import useLocale from "#hooks/use-locale"
+import useLocale from "@local/hooks/use-locale"
 
 const HomePageContents = ({ version }) => {
   const { locale, page, globals, localeMap } = useLocale()

--- a/cli/templates/project/src/components/link.js
+++ b/cli/templates/project/src/components/link.js
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types"
 import NextLink from "next/link"
-import useLocale from "#hooks/use-locale"
+import useLocale from "@local/hooks/use-locale"
 import { defaultLocale } from "../config-locales"
 
 /**

--- a/cli/templates/project/src/components/nav/nav-transition.module.scss
+++ b/cli/templates/project/src/components/nav/nav-transition.module.scss
@@ -1,4 +1,4 @@
-@use "../../styles/helpers/helpers-animation" as *;
+@use "@local/styles/helpers/helpers-animation" as *;
 
 .enter {
   opacity: 0;

--- a/cli/templates/project/src/components/nav/nav.js
+++ b/cli/templates/project/src/components/nav/nav.js
@@ -1,17 +1,17 @@
 import { Fragment, useEffect, useRef, useState } from "react"
 import { CSSTransition } from "react-transition-group"
 
-import Link from "#components/link"
-import ReducedMotionButton from "#components/reduced-motion-button/reduced-motion-button"
-import SkipToButton from "#components/skip-to-button/skip-to-button"
+import Link from "@local/components/link"
+import ReducedMotionButton from "@local/components/reduced-motion-button/reduced-motion-button"
+import SkipToButton from "@local/components/skip-to-button/skip-to-button"
 
-import classnames from "#utils/classnames"
+import classnames from "@local/utils/classnames"
 
 import * as styles from "./nav.module.scss"
 import navTransition from "./nav-transition.module.scss"
 
-import useLocale from "#hooks/use-locale"
-import useBreakpoints from "#hooks/use-breakpoints"
+import useLocale from "@local/hooks/use-locale"
+import useBreakpoints from "@local/hooks/use-breakpoints"
 
 const duration = 400
 

--- a/cli/templates/project/src/components/nav/nav.module.scss
+++ b/cli/templates/project/src/components/nav/nav.module.scss
@@ -1,7 +1,7 @@
-@use "../../styles/helpers/helpers-layout" as *;
-@use "../../styles/helpers/helpers-animation" as *;
-@use "../../styles/settings/settings-breakpoints" as *;
-@use "../../styles/settings/settings-layout" as *;
+@use "@local/styles/helpers/helpers-layout" as *;
+@use "@local/styles/helpers/helpers-animation" as *;
+@use "@local/styles/settings/settings-breakpoints" as *;
+@use "@local/styles/settings/settings-layout" as *;
 
 .a11yBar {
   align-items: center;

--- a/cli/templates/project/src/components/page-head.js
+++ b/cli/templates/project/src/components/page-head.js
@@ -11,7 +11,7 @@
 
 import Head from "next/head"
 import { useRouter } from "next/router"
-import useLocale from "#hooks/use-locale"
+import useLocale from "@local/hooks/use-locale"
 import localeConfig, { defaultLocale } from "../config-locales"
 
 const fallbackTitle = "DON'T FORGET TO ADD A TITLE!"

--- a/cli/templates/project/src/components/page-transition/page-transition.js
+++ b/cli/templates/project/src/components/page-transition/page-transition.js
@@ -5,8 +5,8 @@ import { useRouter } from "next/router";
 import { useUserPrefs } from "@wethegit/react-hooks";
 
 import { locales } from "../../config-locales";
-import { PAGE_TRANSITION_STATE } from "#context/site-state-context";
-import useSiteState from "#hooks/use-site-state";
+import { PAGE_TRANSITION_STATE } from "@local/context/site-state-context";
+import useSiteState from "@local/hooks/use-site-state";
 
 import * as styles from "./page-transition.module.scss";
 

--- a/cli/templates/project/src/components/page/page.js
+++ b/cli/templates/project/src/components/page/page.js
@@ -1,13 +1,13 @@
 import { useEffect } from "react";
 import localesConfig from "../../config-locales";
-import useLocale from "#hooks/use-locale";
+import useLocale from "@local/hooks/use-locale";
 
-import BodyScripts from "#components/body-scripts";
-import Footer from "#components/footer/footer";
-import Nav from "#components/nav/nav";
-import PageHead from "#components/page-head";
+import BodyScripts from "@local/components/body-scripts";
+import Footer from "@local/components/footer/footer";
+import Nav from "@local/components/nav/nav";
+import PageHead from "@local/components/page-head";
 
-import classnames from "#utils/classnames";
+import classnames from "@local/utils/classnames";
 
 import * as styles from "./page.module.scss";
 

--- a/cli/templates/project/src/components/picture.js
+++ b/cli/templates/project/src/components/picture.js
@@ -1,6 +1,6 @@
 import { useEffect, useRef, forwardRef, useState } from "react"
-import classnames from "#utils/classnames"
-import { breakpointMap, breakpointOrder } from "#utils/layout"
+import classnames from "@local/utils/classnames"
+import { breakpointMap, breakpointOrder } from "@local/utils/layout"
 import register from "../../images_register.json"
 
 /**

--- a/cli/templates/project/src/components/reduced-motion-button/reduced-motion-button.js
+++ b/cli/templates/project/src/components/reduced-motion-button/reduced-motion-button.js
@@ -1,9 +1,9 @@
 import { useUserPrefs } from "@wethegit/react-hooks";
 
-import useLocale from "#hooks/use-locale";
+import useLocale from "@local/hooks/use-locale";
 
-import { castToBool } from "#utils/utils";
-import classnames from "#utils/classnames";
+import { castToBool } from "@local/utils/utils";
+import classnames from "@local/utils/classnames";
 
 import {
   rmButton,

--- a/cli/templates/project/src/components/reduced-motion-button/reduced-motion-button.module.scss
+++ b/cli/templates/project/src/components/reduced-motion-button/reduced-motion-button.module.scss
@@ -1,4 +1,4 @@
-@use "../../styles/helpers/helpers-layout" as *;
+@use "@local/styles/helpers/helpers-layout" as *;
 
 .rmButton {
   align-items: center;

--- a/cli/templates/project/src/components/skip-to-button/skip-to-button.js
+++ b/cli/templates/project/src/components/skip-to-button/skip-to-button.js
@@ -1,7 +1,7 @@
 import { skipTo } from "./skip-to-button.module.scss"
-import useLocale from "#hooks/use-locale"
+import useLocale from "@local/hooks/use-locale"
 
-import classnames from "#utils/classnames"
+import classnames from "@local/utils/classnames"
 
 const SkipToButton = ({ anchor, text, className }) => {
   if (anchor.indexOf("#") !== 0) {

--- a/cli/templates/project/src/components/skip-to-button/skip-to-button.module.scss
+++ b/cli/templates/project/src/components/skip-to-button/skip-to-button.module.scss
@@ -1,5 +1,5 @@
-@use "../../styles/helpers/helpers-a11y" as *;
-@use "../../styles/helpers/helpers-layout" as *;
+@use "@local/styles/helpers/helpers-a11y" as *;
+@use "@local/styles/helpers/helpers-layout" as *;
 
 .skipTo {
   display: block;

--- a/cli/templates/project/src/context/locale-context.js
+++ b/cli/templates/project/src/context/locale-context.js
@@ -15,7 +15,7 @@
  */
 
 import { createContext, useState, useEffect, useContext } from "react"
-import { SiteStateContext } from "#context/site-state-context"
+import { SiteStateContext } from "@local/context/site-state-context"
 
 const LocaleContext = createContext()
 

--- a/cli/templates/project/src/hooks/use-locale.js
+++ b/cli/templates/project/src/hooks/use-locale.js
@@ -12,9 +12,9 @@
  */
 
 import { useContext } from "react";
-import { LocaleContext } from "#context/locale-context";
-import { PageContext } from "#context/page-context";
-import { SiteStateContext } from "#context/site-state-context";
+import { LocaleContext } from "@local/context/locale-context";
+import { PageContext } from "@local/context/page-context";
+import { SiteStateContext } from "@local/context/site-state-context";
 
 const useLocale = (setPage) => {
   const localeCache = useContext(LocaleContext);

--- a/cli/templates/project/src/hooks/use-site-state.js
+++ b/cli/templates/project/src/hooks/use-site-state.js
@@ -1,5 +1,5 @@
 import { useContext } from "react"
-import { SiteStateContext } from "#context/site-state-context"
+import { SiteStateContext } from "@local/context/site-state-context"
 
 const useSiteState = () => useContext(SiteStateContext)
 

--- a/cli/templates/project/src/pages/404.js
+++ b/cli/templates/project/src/pages/404.js
@@ -1,4 +1,4 @@
-import { setupProps } from "#utils/page-setup"
+import { setupProps } from "@local/utils/page-setup"
 
 const Four0hFour = ({ locale, globals }) => {
   return (

--- a/cli/templates/project/src/pages/500.js
+++ b/cli/templates/project/src/pages/500.js
@@ -1,4 +1,4 @@
-import { setupProps } from "#utils/page-setup"
+import { setupProps } from "@local/utils/page-setup"
 
 const FiveHundred = ({ locale, globals }) => {
   return (

--- a/cli/templates/project/src/pages/[locale]/index.js
+++ b/cli/templates/project/src/pages/[locale]/index.js
@@ -1,11 +1,11 @@
 import { useEffect } from "react"
 import { useRouter } from "next/router"
 
-import { setupPaths, setupProps } from "#utils/page-setup"
+import { setupPaths, setupProps } from "@local/utils/page-setup"
 import { defaultLocale } from "../../config-locales"
 
-import HomePageContents from "#components/home-page-contents/home-page-contents"
-import PageProvider from "#context/page-context"
+import HomePageContents from "@local/components/home-page-contents/home-page-contents"
+import PageProvider from "@local/context/page-context"
 
 const LOCALE_FOLDER = "home"
 const Home = ({ locale, ...pageProps }) => {

--- a/cli/templates/project/src/pages/[locale]/subpage/index.js
+++ b/cli/templates/project/src/pages/[locale]/subpage/index.js
@@ -1,6 +1,6 @@
-import { setupPaths, setupProps } from "#utils/page-setup";
-import PageProvider from "#context/page-context";
-import useLocale from "#hooks/use-locale";
+import { setupPaths, setupProps } from "@local/utils/page-setup";
+import PageProvider from "@local/context/page-context";
+import useLocale from "@local/hooks/use-locale";
 
 const LOCALE_FOLDER = "subpage";
 

--- a/cli/templates/project/src/pages/_app.js
+++ b/cli/templates/project/src/pages/_app.js
@@ -1,6 +1,6 @@
-import AppContextProviders from "#components/app-context-providers";
-import Page from "#components/page/page";
-import PageTransition from "#components/page-transition/page-transition";
+import AppContextProviders from "@local/components/app-context-providers";
+import Page from "@local/components/page/page";
+import PageTransition from "@local/components/page-transition/page-transition";
 import { useRouter } from "next/router";
 
 import "../styles/globals.scss";

--- a/cli/templates/project/src/pages/index.js
+++ b/cli/templates/project/src/pages/index.js
@@ -1,7 +1,7 @@
-import { setupProps } from "#utils/page-setup"
+import { setupProps } from "@local/utils/page-setup"
 
-import HomePageContents from "#components/home-page-contents/home-page-contents"
-import PageProvider from "#context/page-context"
+import HomePageContents from "@local/components/home-page-contents/home-page-contents"
+import PageProvider from "@local/context/page-context"
 
 const LOCALE_FOLDER = "home"
 export default function RootRedirect({ ...pageProps }) {

--- a/cli/templates/project/src/styles/base/resets.scss
+++ b/cli/templates/project/src/styles/base/resets.scss
@@ -1,4 +1,4 @@
-@use "../helpers/helpers-typography" as *;
+@use "@local/styles/helpers/helpers-typography" as *;
 
 // Most of this is taken from the normalize.css package:
 // https://necolas.github.io/normalize.css/8.0.1/normalize.css

--- a/cli/templates/project/src/styles/base/typography.scss
+++ b/cli/templates/project/src/styles/base/typography.scss
@@ -2,7 +2,7 @@
 // `styles/utility-classes/utils-typography.scss` file, alongside the typography
 // utility classes.
 
-@use "../helpers/helpers-typography" as *;
+@use "@local/styles/helpers/helpers-typography" as *;
 
 :root {
   --font-body: "Open Sans", sans-serif;

--- a/cli/templates/project/src/styles/globals.scss
+++ b/cli/templates/project/src/styles/globals.scss
@@ -1,26 +1,26 @@
 // Mixins/helpers specific to this file:
-@use "./helpers/helpers-a11y" as *;
+@use "@local/styles/helpers/helpers-a11y" as *;
 
 // Global settings and variables
-@import "./settings/settings-animation";
-@import "./settings/settings-breakpoints";
-@import "./settings/settings-color";
-@import "./settings/settings-layout";
-@import "./settings/settings-reduced-motion";
+@import "@local/styles/settings/settings-animation";
+@import "@local/styles/settings/settings-breakpoints";
+@import "@local/styles/settings/settings-color";
+@import "@local/styles/settings/settings-layout";
+@import "@local/styles/settings/settings-reduced-motion";
 
 // Global style declarations:
-@import "./base/resets.scss";
-@import "./base/layout.scss";
-@import "./base/typography.scss";
+@import "@local/styles/base/resets.scss";
+@import "@local/styles/base/layout.scss";
+@import "@local/styles/base/typography.scss";
 
 // Global utility classes:
-@import "./utility-classes/utils-a11y.scss";
-@import "./utility-classes/utils-breakpoints.scss";
-@import "./utility-classes/utils-color.scss";
-@import "./utility-classes/utils-image.scss";
-@import "./utility-classes/utils-in-view.scss";
-@import "./utility-classes/utils-layout.scss";
-@import "./utility-classes/utils-typography.scss";
+@import "@local/styles/utility-classes/utils-a11y.scss";
+@import "@local/styles/utility-classes/utils-breakpoints.scss";
+@import "@local/styles/utility-classes/utils-color.scss";
+@import "@local/styles/utility-classes/utils-image.scss";
+@import "@local/styles/utility-classes/utils-in-view.scss";
+@import "@local/styles/utility-classes/utils-layout.scss";
+@import "@local/styles/utility-classes/utils-typography.scss";
 
 *:focus {
   @include focus-style;

--- a/cli/templates/project/src/styles/helpers/_helpers-images.scss
+++ b/cli/templates/project/src/styles/helpers/_helpers-images.scss
@@ -1,4 +1,4 @@
-@use "./helpers-math" as *;
+@use "@local/styles/helpers/helpers-math" as *;
 
 // Responsively positions a child element relative to its parent container.
 // Expects unitless values as input.

--- a/cli/templates/project/src/styles/helpers/_helpers-layout.scss
+++ b/cli/templates/project/src/styles/helpers/_helpers-layout.scss
@@ -1,4 +1,4 @@
-@use "./helpers-math";
+@use "@local/styles/helpers/helpers-math";
 
 // Absolutely positions an element, with an optional inset.
 @mixin full-absolute($inset: 0) {

--- a/cli/templates/project/src/styles/js-exports.module.scss
+++ b/cli/templates/project/src/styles/js-exports.module.scss
@@ -1,6 +1,6 @@
 /* stylelint-disable property-no-unknown */
-@import "./settings/settings-breakpoints";
-@import "./settings/settings-layout";
+@import "@local/styles/settings/settings-breakpoints";
+@import "@local/styles/settings/settings-layout";
 
 :export {
   breakpoint-large: $large;

--- a/cli/templates/project/src/styles/utility-classes/utils-a11y.scss
+++ b/cli/templates/project/src/styles/utility-classes/utils-a11y.scss
@@ -1,4 +1,4 @@
-@use "../helpers/helpers-a11y" as *;
+@use "@local/styles/helpers/helpers-a11y" as *;
 
 .focus-reverse:focus {
   @include focus-style-reverse;

--- a/cli/templates/project/src/styles/utility-classes/utils-image.scss
+++ b/cli/templates/project/src/styles/utility-classes/utils-image.scss
@@ -1,5 +1,5 @@
-@use "../helpers/helpers-images" as *;
-@use "../helpers/helpers-math" as *;
+@use "@local/styles/helpers/helpers-images" as *;
+@use "@local/styles/helpers/helpers-math" as *;
 
 .image-group {
   --parent-width: 0;

--- a/cli/templates/project/src/styles/utility-classes/utils-in-view.scss
+++ b/cli/templates/project/src/styles/utility-classes/utils-in-view.scss
@@ -1,5 +1,5 @@
-@use "../helpers/helpers-a11y" as *;
-@use "../helpers/helpers-in-view" as *;
+@use "@local/styles/helpers/helpers-a11y" as *;
+@use "@local/styles/helpers/helpers-in-view" as *;
 
 // All in-view animations are based around a handful of CSS
 // custom properties, so you can easily create your own custom

--- a/cli/templates/project/src/styles/utility-classes/utils-layout.scss
+++ b/cli/templates/project/src/styles/utility-classes/utils-layout.scss
@@ -1,4 +1,4 @@
-@use "../helpers/helpers-layout" as *;
+@use "@local/styles/helpers/helpers-layout" as *;
 
 // Generates "row" class names (for flex layout) for the given breakpoint
 @mixin add-grid-row($size: null) {

--- a/cli/templates/project/src/styles/utility-classes/utils-typography.scss
+++ b/cli/templates/project/src/styles/utility-classes/utils-typography.scss
@@ -1,4 +1,4 @@
-@use "../helpers/helpers-typography" as *;
+@use "@local/styles/helpers/helpers-typography" as *;
 
 h1,
 .title-1,

--- a/docs/docs/hooks/use-breakpoints.mdx
+++ b/docs/docs/hooks/use-breakpoints.mdx
@@ -27,7 +27,7 @@ The `useBreakpoints` hook provides us with the current breakpoint. This value is
 ## Usage
 
 ```jsx
-import useBreakpoints from "#hooks/use-breakpoints";
+import useBreakpoints from "@local/hooks/use-breakpoints";
 
 import MyMobileDeviceComponent from "../somewhere"
 import WildlyDifferentDesktopComponent from "../somewhere"

--- a/docs/docs/hooks/use-locale.mdx
+++ b/docs/docs/hooks/use-locale.mdx
@@ -32,7 +32,7 @@ The `useLocale` hook allows you to easily retrieve various pieces of locale-spec
 General, component-level usage of the `useLocale` hook is straightforward—just call the function and you're done. In this example, we're destructuring a few properties from the hook's return value, and logging them out:
 
 ```jsx
-import useLocale from "#hooks/use-locale";
+import useLocale from "@local/hooks/use-locale";
 
 const MyComponent = () => {
   const { globals, page, pageName, locale } = useLocale();
@@ -51,7 +51,7 @@ const MyComponent = () => {
 When used within a [**page component**](../pages/page-components), the `pageDirectoryName` is a required argument. In this scenario, we'll bind that value to `LOCALE_FOLDER` and pass _it_ in, as this value gets used in a few other places throughout the page component.
 
 ```jsx
-import useLocale from "#hooks/use-locale";
+import useLocale from "@local/hooks/use-locale";
 
 const LOCALE_FOLDER = "about";
 // for nested pages, this might look more like "work/advertising"

--- a/docs/docs/hooks/use-site-settings.mdx
+++ b/docs/docs/hooks/use-site-settings.mdx
@@ -36,7 +36,7 @@ The following is just an example of the many things you _could_ do with this hoo
 
 ```jsx
 import { useEffect } from "react"
-import useSiteState from "#hooks/use-site-state";
+import useSiteState from "@local/hooks/use-site-state";
 
 const MyComponent = () => {
   const { setBackground } = useSiteState();
@@ -51,7 +51,7 @@ const MyComponent = () => {
 ```
 
 ```jsx title=/src/containers/page.js
-import useSiteState from "#hooks/use-site-state";
+import useSiteState from "@local/hooks/use-site-state";
 
 const Page = ({ children, className, version }) => {
   const { background } = useSiteState();

--- a/docs/docs/images/picture-component.mdx
+++ b/docs/docs/images/picture-component.mdx
@@ -28,7 +28,7 @@ There are two things to take note of here:
 - corgi recognizes that the source image is a PNG, and thus generates a WEBP version as well.
 
 ```jsx title="<Picture> component usage"
-import Picture from "#components/picture";
+import Picture from "@local/components/picture";
 
 const MyComponent = () => (
   <Picture

--- a/docs/docs/localization/data.mdx
+++ b/docs/docs/localization/data.mdx
@@ -60,7 +60,7 @@ footer: © Company Name.
 As mentioned, that data gets compiled into a page-level prop called `globals`, for the current page and locale. Here's an example that uses that data (via [`useLocale`](./use-locale-hook)) from within an imaginary `<Navigation />` component:
 
 ```jsx title=/src/components/navigation.js
-import useLocale from "#hooks/use-locale"
+import useLocale from "@local/hooks/use-locale"
 
 const Navigation = () => {
   const { globals } = useLocale()
@@ -107,7 +107,7 @@ features:
 This data gets compiled into a page-level prop called `page`, for the current page and locale. Here's an example that uses that data (via [`useLocale`](./use-locale-hook)) from within an imaginary `<FeatureList>` component:
 
 ```jsx title=/src/components/feature-list.js
-import useLocale from "#hooks/use-locale";
+import useLocale from "@local/hooks/use-locale";
 
 const FeatureList = ({}) => {
   const { page } = useLocale();

--- a/docs/docs/localization/use-locale-hook.mdx
+++ b/docs/docs/localization/use-locale-hook.mdx
@@ -12,7 +12,7 @@ corgi's built-in React hook, `useLocale` allows you to easily pull in various pi
 For the most part, you can use the `useLocale` hook as shown here. This example destructures the returned object, into just the `globals` and `page` objects.
 
 ```jsx
-import useLocale from "#hooks/use-locale";
+import useLocale from "@local/hooks/use-locale";
 
 const MyComponent = () => {
   const { globals, page } = useLocale();
@@ -29,7 +29,7 @@ const MyComponent = () => {
 If using this hook at the page-level—i.e. from a component defined as a page within the `/src/pages/` directory—you _must_ pass the **locale folder name** to the hook. This acts a sort of "initialization" step for the hook. All lower-level uses of the hook do not require this step. In this example, we're looking at an imaginary About page component. The locale folder name is declared at the top of the file, and is then passed into the `useLocale` hook:
 
 ```jsx title=/src/pages/[locale]/about/index.js
-import useLocale from "#hooks/use-locale";
+import useLocale from "@local/hooks/use-locale";
 
 const LOCALE_FOLDER = "about";
 // for nested pages, this might look more like "work/advertising"

--- a/docs/docs/pages/page-components.mdx
+++ b/docs/docs/pages/page-components.mdx
@@ -21,9 +21,9 @@ For clarity, the term "page component" here is _not_ to be confused with Next.js
 Here's an example `index.js` file for a page component. We'll break it down in the following sections.
 
 ```jsx
-import { setupPaths, setupProps } from "#utils/page-setup";
-import PageProvider from "#context/page-context";
-import useLocale from "#hooks/use-locale";
+import { setupPaths, setupProps } from "@local/utils/page-setup";
+import PageProvider from "@local/context/page-context";
+import useLocale from "@local/hooks/use-locale";
 
 const LOCALE_FOLDER = "about";
 

--- a/docs/docs/quick-start/localize-your-content.mdx
+++ b/docs/docs/quick-start/localize-your-content.mdx
@@ -97,7 +97,7 @@ The `useLocale` hook will allow you to retrieve locale information from within a
 ### Global data example:
 
 ```jsx title=/src/components/footer/footer.js
-import useLocale from "#hooks/use-locale";
+import useLocale from "@local/hooks/use-locale";
 
 const Footer = ({ children }) => {
   const { globals } = useLocale();
@@ -115,7 +115,7 @@ export default Footer;
 ### Page and global data example:
 
 ```jsx title=/src/components/home-page-contents/home-page-contents.js
-import useLocale from "#hooks/use-locale";
+import useLocale from "@local/hooks/use-locale";
 
 const HomePageContents = ({}) => {
   const { locale, page, globals } = useLocale()

--- a/docs/docs/styles/component-styles.mdx
+++ b/docs/docs/styles/component-styles.mdx
@@ -32,7 +32,7 @@ If you prefer not to use CSS Modules, you're free to use the CSS workflow of you
 
 ```jsx title="/src/components/button/button.js"
 import * as styles from "./button.module.scss";
-import Icon from "#components/icon/icon";
+import Icon from "@local/components/icon/icon";
 
 const Button = ({ children }) => {
   return (

--- a/docs/docs/styles/grid-system.mdx
+++ b/docs/docs/styles/grid-system.mdx
@@ -118,7 +118,7 @@ In addition to providing classNames, the flex-grid system also provides some SCS
 Function. Returns a percentage that conforms to the number of columns provided. This is useful when trying to offset columns by a specific number of columns (via left or right margin, for example). The following example will add two columns worth of left margin.
 
 ```scss title="grid-calc example"
-@use "../../styles/helpers/helpers-layout" as *;
+@use "@local/styles/helpers/helpers-layout" as *;
 
 .my-element {
   margin-left: grid-calc(2);

--- a/docs/docs/styles/responsive-breakpoints.mdx
+++ b/docs/docs/styles/responsive-breakpoints.mdx
@@ -31,7 +31,7 @@ These breakpoints are written with a mobile-first methodology in mind. Part of t
 ## Usage
 
 ```scss title="Example component: /src/components/section/section.module.scss"
-@use "../../styles/settings/settings-breakpoints" as *;
+@use "@local/styles/settings/settings-breakpoints" as *;
 
 .mySection {
   padding: 1rem;

--- a/docs/docs/subpath-aliases.mdx
+++ b/docs/docs/subpath-aliases.mdx
@@ -1,0 +1,32 @@
+---
+sidebar_position: 9
+---
+
+# Subpath aliases
+
+By default, corgi sets up a few subpath aliases to help you manage your imports. This becomes especially useful when importing modules from within deeply-nested components or pages.  
+
+The following aliases are available:  
+
+
+| alias               | location       |
+| ------------------- | -------------- |
+| `@local/components` | src/components |
+| `@local/context`    | src/context    |
+| `@local/hooks`      | src/hooks      |
+| `@local/utils`      | src/utils      |
+| `@local/styles`     | src/styles     |
+
+## Usage
+
+### JavaScript imports
+```jsx title=src/pages/[locale]/about/index.js
+import Button from "@local/components/button/button"
+import useBreakpoints from "@local/hooks/use-breakpoints"
+```
+
+### SCSS imports
+```scss title=src/components/your-component/your-component.module.scss
+@use "@local/styles/helpers/helpers-animation" as *;
+@use "@local/styles/helpers/helpers-math" as *;
+```


### PR DESCRIPTION
# What this does
Adds local subpath aliases for component, hook, util, and context directories.

## Why it does it
Because relative imports get messy!

## Usage
### Before:
```js
import MyComponent from '../../../../components/my-component/my-component'
```
### After:
```js
import MyComponent from '@local/components/my-component/my-component'
```

## Notes
- There are a lot of changes in this PR, the important one is in `/next.config.js` (here's a link to [that commit](https://github.com/wethegit/corgi/pull/26/commits/e02301bbf1dd29c52efb28408a607e3295d34d3d))
- Using these aliases on a project is totally optional. A big motivation for this was the need for having deeply-nested component structures on external Corgi templates — relative paths would require some frustratingly imperative custom tooling to deal with, in those scenarios.