### PR TITLE
Feature/refactor-breakpoints-hook

### DIFF
--- a/cli/templates/project/src/components/nav/nav.js
+++ b/cli/templates/project/src/components/nav/nav.js
@@ -18,7 +18,7 @@ const duration = 400
 const Nav = ({}) => {
   const { globals, page } = useLocale()
   const [open, setOpen] = useState(false)
-  const currentBP = useBreakpoints()
+  const { breakpoint } = useBreakpoints()
 
   // This ref is just to avoid the "findDOMNode in strictMode" error:
   // https://github.com/reactjs/react-transition-group/issues/668
@@ -27,8 +27,8 @@ const Nav = ({}) => {
   const toggle = () => setOpen(!open)
 
   useEffect(() => {
-    if (currentBP > 2) setOpen(false)
-  }, [currentBP])
+    if (breakpoint > 2) setOpen(false)
+  }, [breakpoint])
 
   return (
     <div
@@ -47,7 +47,7 @@ const Nav = ({}) => {
         </li>
       </menu>
 
-      {currentBP < 3 && (
+      {breakpoint < 3 && (
         <button
           className={classnames([styles.toggler, open && styles.togglerPressed])}
           aria-live="polite"
@@ -69,9 +69,9 @@ const Nav = ({}) => {
         for the desktop experience (i.e. breakpoint is greater than 2) */
         }
 
-        const WrapperTag = currentBP > 2 ? Fragment : CSSTransition
+        const WrapperTag = breakpoint > 2 ? Fragment : CSSTransition
         const wrapperProps =
-          currentBP > 2
+          breakpoint > 2
             ? {}
             : {
                 classNames: navTransition,

--- a/cli/templates/project/src/hooks/use-breakpoints.js
+++ b/cli/templates/project/src/hooks/use-breakpoints.js
@@ -1,15 +1,15 @@
 import { useCallback, useEffect, useState } from "react"
 
 const BREAKPOINT_MAP = new Map([
-  ["S", 1],
-  ["M", 2],
-  ["L", 3],
-  ["XL", 4],
-  ["XXL", 5],
+  ["S", [1, "small"]],
+  ["M", [2, "medium"]],
+  ["L", [3, "large"]],
+  ["XL", [4, "xlarge"]],
+  ["XXL", [5, "xxlarge"]],
 ])
 
 const useBreakpoints = () => {
-  const [currentBP, setCurrentBP] = useState(null)
+  const [currentBP, setCurrentBP] = useState([null, null])
 
   const handleResize = useCallback((e) => {
     if (typeof window === "undefined") return
@@ -26,16 +26,14 @@ const useBreakpoints = () => {
   useEffect(() => {
     window.addEventListener("resize", handleResize)
 
+    handleResize()
+
     return () => {
       window.removeEventListener("resize", handleResize)
     }
-  })
+  }, [])
 
-  useEffect(() => {
-    handleResize()
-  }, [handleResize])
-
-  return currentBP
+  return { breakpoint: currentBP[0], breakpointName: currentBP[1] }
 }
 
 export default useBreakpoints

--- a/docs/docs/hooks/use-breakpoints.mdx
+++ b/docs/docs/hooks/use-breakpoints.mdx
@@ -10,19 +10,20 @@ The `useBreakpoints` hook provides us with the current breakpoint. This value is
 
 ## Return value
 
-`useBreakpoints` returns an integer which corresponds to a breakpoint based on the following mapping:
+`useBreakpoints` returns an object containing two values — the breakpoint name ("small", "medium", etc.), and an integer which corresponds to a breakpoint based on the following mapping:
 
 ```
 1: small
 2: medium
 3: large
-4: x-large
-5: xx-large
+4: xlarge
+5: xxlarge
 ```
 
-| Value      | Type     | Description |
-| ---------- | -------- | ----------- |
-| breakpoint | Number   | An integer representation of the current breakpoint. |
+| Value          | Type     | Description                                          |
+| -------------- | -------- | ---------------------------------------------------- |
+| breakpoint     | Number   | An integer representation of the current breakpoint. |
+| breakpointName | String   | A string representation of the current breakpoint.   |
 
 ## Usage
 
@@ -33,7 +34,9 @@ import MyMobileDeviceComponent from "../somewhere"
 import WildlyDifferentDesktopComponent from "../somewhere"
 
 const MyComponent = () => {
-  const breakpoint = useBreakpoints()
+  const { breakpoint, breakpointName } = useBreakpoints()
+
+  console.log(breakpointName === "small") // => logs true or false
 
   return breakpoint < 3 ? (
     <MyMobileDeviceComponent />


### PR DESCRIPTION
# What this does
- Consolodates some of the function calls in the `useBreakpoints` hook
- Adds a new return value for useBreakpoints, which includes the breakpoint name.

## Why
The existing integer => breakpoint mapping is not always easy to work with, and sometimes you just need to say "render this thing when the breakpoint  === 'medium' "

## Usage
```jsx
const MyComponent = () => {
  const { breakpoint, breakpointName } = useBreakpoints()

  console.log(breakpoint) // => 1, 2, 3, 4, or 5

  console.log(breakpointName) // => "small", "medium", "large", etc.
}
```