### PR TITLE
feat: allow for dynamic TLDN values

### DIFF
--- a/cli/templates/project/src/components/page-head.js
+++ b/cli/templates/project/src/components/page-head.js
@@ -13,6 +13,7 @@ import Head from "next/head"
 import { useRouter } from "next/router"
 import useLocale from "@local/hooks/use-locale"
 import localeConfig, { defaultLocale } from "../config-locales"
+import { TLDN } from '../consts'
 
 const fallbackTitle = "DON'T FORGET TO ADD A TITLE!"
 const fallbackDesc = "DON'T FORGET TO ADD A DESCRIPTION!"
@@ -22,7 +23,7 @@ const PageHead = ({}) => {
   const router = useRouter()
 
   const getPageUrl = () => {
-    return process.env.NEXT_PUBLIC_URL + router.asPath
+    return TLDN + router.asPath
   }
 
   const getTitle = () => {
@@ -87,7 +88,7 @@ const PageHead = ({}) => {
         if (path.length > 1) path = path + "/"
 
         // replace the [locale] in the path with the actual altLocale
-        let href = process.env.NEXT_PUBLIC_URL + path.replace("[locale]", altLocale)
+        let href = TLDN + path.replace("[locale]", altLocale)
 
         // return the tag
         return <link key={altLocale} rel="alternate" hrefLang={lang} href={href} />

--- a/cli/templates/project/src/consts.js
+++ b/cli/templates/project/src/consts.js
@@ -1,0 +1,1 @@
+export const TLDN = process.env.NEXT_PUBLIC_URL

--- a/cli/templates/project/src/pages/_document.js
+++ b/cli/templates/project/src/pages/_document.js
@@ -10,6 +10,7 @@
 
 import { Html, Head, Main, NextScript } from "next/document"
 import { defaultLocale } from "../config-locales"
+import { TLDN } from '../consts'
 
 export default function Document() {
   return (
@@ -17,11 +18,11 @@ export default function Document() {
       <Head>
         <meta content="website" property="og:type" />
         <meta
-          content={`${process.env.NEXT_PUBLIC_URL}/images/share-fb.jpg`}
+          content={`${TLDN}/images/share-fb.jpg`}
           property="og:image"
         />
         <meta
-          content={`${process.env.NEXT_PUBLIC_URL}/images/share-tw.jpg`}
+          content={`${TLDN}/images/share-tw.jpg`}
           name="twitter:image"
         />
 


### PR DESCRIPTION
This adds a file `/src/consts.js` which, at the moment, only exports a variable `TLDN`. This will allow users of custom Corgi templates to more easily specify overrides for server environments and such. For example:

```
const TLDN = process.env.MY_TEST_SERVER_TLDN || process.env.NEXT_PUBLIC_URL
```