### PR TITLE
feature: clickable path aliases

### DIFF
--- a/cli/templates/project/jsconfig.json
+++ b/cli/templates/project/jsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "baseUrl": ".",
+    "paths": {
+      "@local/components/*": ["./src/components/*"],
+      "@local/context/*": ["./src/context/*"],
+      "@local/hooks/*": ["./src/hooks/*"],
+      "@local/utils/*": ["./src/utils/*"],
+      "@local/styles/*": ["./src/styles/*"]
+    }
+  }
+}


### PR DESCRIPTION
## Goal
The goal of this PR is to provide a better developer experience by enabling VS Code and other editors to read the aliases we have setup so we can do things like:
- command+click a path to go to it's file
- right click and be able to go to definition
- and more