### PR TITLE
fix(image helpers): add -webkit prefix to @image-set SASS mixin.

### DIFF
--- a/cli/templates/project/src/styles/helpers/_helpers-images.scss
+++ b/cli/templates/project/src/styles/helpers/_helpers-images.scss
@@ -16,6 +16,6 @@
 // an image-set with a fallback.
 @mixin image-set($source1x, $source2x) {
   background-image: url(#{$source1x});
-  background-image: image-set(url(#{$source1x}) 1x, url(#{$source2x}) 2x);
+  background-image: -webkit-image-set(url(#{$source1x}) 1x, url(#{$source2x}) 2x);
   background-image: image-set(url(#{$source1x}) 1x, url(#{$source2x}) 2x);
 }


### PR DESCRIPTION
This fixes the missing -webkit prefix on our image-set mixin.

Note that this does not solve the problem mentioned in #34, since Stylelint is an addon via a custom project template. Will address that issue separately, in that repo.