### PR TITLE
Sitemap: ignore defaultLocale root path

### DIFF
--- a/cli/templates/project/next-sitemap.js
+++ b/cli/templates/project/next-sitemap.js
@@ -7,4 +7,5 @@ const { defaultLocale } = require("./src/config-locales")
 module.exports = {
   siteUrl: process.env.NEXT_PUBLIC_URL,
   generateRobotsTxt: true,
+  exclude: [`/${defaultLocale}`],
 }


### PR DESCRIPTION
# What this does
Removes the default locale from the _explicit_ root path, i.e. `mywebsite.com/en-us/` when the default locale is `en-us`. This way, we don't have two entries for the same page: `/` and `/en-us`

Fixes #29