### PR TITLE
Separate package JSON config from other potential configs

### DIFF
--- a/cli/bin/index.js
+++ b/cli/bin/index.js
@@ -10,7 +10,7 @@ const program = new Command();
 
 program
   .name("corgi")
-  .description("Welcome to the corgi CLI. Here's the description.");
+  .description("Welcome to the corgi CLI. Please enter a valid command, like `corgi project`, `corgi page`, or `corgi component`.");
 
 program
   .command("project")

--- a/cli/consts.js
+++ b/cli/consts.js
@@ -1,10 +1,12 @@
 const CONSTS = {
   CONFIG_FILENAME: "corgi-project.config.json",
   CONFIG_DEFAULTS: {
-    name: "corgi-project",
-    dependencies: {},
-    devDependencies: {},
-    scripts: {},
+    package: {
+      name: "corgi-project",
+      dependencies: {},
+      devDependencies: {},
+      scripts: {},
+    }
   },
   QUESTIONS: [
     {

--- a/cli/lib/merge-package-properties.js
+++ b/cli/lib/merge-package-properties.js
@@ -1,10 +1,7 @@
 const mergePkgProperties = ({ existing, custom }) => {
   const merged = { ...existing };
-  const validProps = ["name", "scripts", "dependencies", "devDependencies"];
 
   for (const [key, value] of Object.entries(custom)) {
-    if (!validProps.includes(key)) continue;
-
     if (typeof value === "string") {
       merged[key] = custom[key];
     } else if (Array.isArray(value)) {


### PR DESCRIPTION
# What this does
- Compartmentalizes the _current_ corgi project config into a `"package"` property. This is in anticipation of future updates where we have some other custom config settings to add which are not related in any way to package.json.
- Removes the restriction of specific properties that you're allowed to add to your `corgi-project.config.json`. Previously you were only allowed to alter `scripts`, `name`, `dependencies`, and `devDependencies`. You're now free to add whatever you want to be merged into the project's package.json.

## To test this locally
- `cd` into your corgi repo
- run the project command locally via `node cli/bin/index.js project my-test-project`
- when prompted for a GitHub template, paste this in: `https://github.com/wethegit/corgi-private-templates/tree/feature/new-config-structure` (this is a test project template I've created for this purpose).

You should see the project bootstrapped in your root folder, with the following custom config merged into the package.json file:

![sample-test-config](https://github.com/wethegit/corgi/assets/30575213/67b21722-0ad9-4ba8-a194-d51f603d8d86)

---

Fixes #35 