### PR TITLE
feature: improves classname util

### DIFF
--- a/cli/templates/project/src/utils/classnames.js
+++ b/cli/templates/project/src/utils/classnames.js
@@ -1,6 +1,7 @@
 export function classnames(classes) {
   if (!classes) return null
   if (typeof classes === 'string') return classes
+  if (!Array.isArray(classes)) return null;
 
-  return classes.flat().filter(c => Boolean(c)).join(" ")
+  return classes.flat().filter(c => typeof c === 'string').join(" ")
 }

--- a/cli/templates/project/src/utils/classnames.js
+++ b/cli/templates/project/src/utils/classnames.js
@@ -1,11 +1,6 @@
-export function classnames(classes = []) {
-  if (!classes || !Array.isArray(classes) || !classes.length) return null
+export function classnames(classes) {
+  if (!classes) return null
+  if (typeof classes === 'string') return classes
 
-  let output = []
-
-  classes.forEach((arg) => {
-    if (typeof arg === "string") output.push(arg)
-  })
-
-  return output.join(" ")
+  return classes.flat().filter(c => Boolean(c)).join(" ")
 }


### PR DESCRIPTION
## Goal
This simplifies the `classname` function and ensures that nested arrays are flattened

This helps with instances where we are uncertain if a component is using the `classnames` function and the `className` prop can either be a string or an array.

For example:

```jsx
// image you have a component that takes a className
// instead of doing this
<Component
  className={className && classnames(Array.isArray(className) ? className : [className])}
/>

// you can simply pass the prop to classnames and it will take care of it
<Component
  className={classnames(className)}
/>
```

Also helps avoid this:
```jsx
<Component
  className={
    classnames([
      'regular-classname',
      className && className
    ])
  }
/>

// can simply pass the prop with everything else
<Component
  className={classnames(['base-classname', className])}
/>
```

## Tests:

![Screenshot 2023-07-06 at 5 18 53 PM](https://github.com/wethegit/corgi/assets/1956448/17d7b09a-f4d6-4109-94d0-f85cca733f09)

