### PR TITLE
fix: eslint alias group

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/corgi",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Command line interface for use with the corgi framework.",
   "main": "bin/index.js",
   "bin": {

--- a/cli/templates/project/.eslintrc.yml
+++ b/cli/templates/project/.eslintrc.yml
@@ -11,7 +11,8 @@ rules:
     - newlines-between: always
       pathGroups:
         - pattern: "@local/**"
-          group: internal
+          group: external
+          position: after
 settings:
   import/resolver:
     alias:


### PR DESCRIPTION
The grouping where actually wrong. The aliases were being reordered to be **after** relative paths, when they should actually be **before** and within their own grouping.