### PR TITLE
fix: ensures locale config is source of truth

### DIFF
--- a/cli/templates/project/src/config-locales.js
+++ b/cli/templates/project/src/config-locales.js
@@ -1,51 +1,47 @@
+/**
+ * Add your required locales here, along with any mapping to specifically-formatted
+ * strings. For example, if your locale string differs from the ISO standard
+ * abbreviation, you can add that here.
+ *   
+ * The mapped object value will be available to both the Page's pageProps and the
+ * useLocales hook as `localeMap`. If the locale is missing from the map then
+ * localeMaps will be an empty object.
+ */
+const localeMap = new Map([
+  [
+    "en",
+    {
+      language: "en-US",
+    },
+  ],
+  [
+    "es",
+    {
+      language: "es-ES",
+    },
+  ],
+  [
+    "fr",
+    {
+      language: "fr-FR",
+    },
+  ],
+]);
+
+
+/**
+ * Make just the locale slugs available (i.e. ["en", "fr", etc.]):
+ */
+const locales = Array.from(localeMap.keys())
+
 module.exports = {
   defaultLocale: "en",
+  locales,
+  localeMap,
 
-  /*
-    locales here are not used to generate pages,
-    however is it useful to store the languages
-    you intend to support here.
-  */
-
-  locales: ["en", "es", "fr"],
-
-  /*
-    Both <html lang=""> and <Link hreflang ... />
-    tags are auto generated for every page. The
-    value for those will default to the locale
-    unless an alternative in the localeMap
-    (see below) is defined here.
-  */
-
+  /** Both <html lang=""> and <Link hreflang ... /> tags are auto generated for every
+   * page. The value for those will default to the locale slug (i.e. "en", "fr", etc.),
+   * unless an alternative property defined the localeMap is specified here:
+   */
   langValue: "language",
-
-  /*
-    if you need to map your locales to specific
-    alternatives then add them here. The mapped
-    object will be available to the page and
-    useLocales hook as localeMaps. If the locale
-    is missing from the map then localeMaps will
-    be an empty object
-  */
-
-  localeMap: new Map([
-    [
-      "en",
-      {
-        language: "en-US",
-      },
-    ],
-    [
-      "es",
-      {
-        language: "es-ES",
-      },
-    ],
-    [
-      "fr",
-      {
-        language: "fr-FR",
-      },
-    ],
-  ]),
 }

--- a/cli/templates/project/src/utils/page-setup.js
+++ b/cli/templates/project/src/utils/page-setup.js
@@ -3,8 +3,11 @@ import localeConfig from "@local/config-locales"
 const { defaultLocale } = localeConfig
 
 const getAvailableLocales = (pageName) => {
+  if (!pageName) return []
   const glob = require("glob")
-  const yamls = glob.sync(`./src/locales/${pageName}/*.{yml, yaml}`)
+  const yamls = Array.from(localeConfig.localeMap.entries())
+    .map(([locale]) => glob.sync(`./src/locales/${pageName}/${locale}.{yml, yaml}`))
+    .flat()
   return yamls.map((path) => path.split("/").pop().split(".").shift())
 }
 


### PR DESCRIPTION
This small fix to page setup ensures that we are configuring our locales instead of basing ourselves on the files inside the locales directory.  

The main reason being that it removes ambiguity.  
The app is split between two sources of truth when it comes to locales at the moment.
`config-locales.js` is used to generate `alternate` lang metas and also provide data to other areas of the app like in the `_document` and `link` components.
But when it comes to generating the pages we use the `locales` directory as our source of truth instead. 

Also this change:
1. Ensures that locale paths are set so we don't get `undefined`s in the source code
2. Only builds locales that are configured, creating an extra layer in avoiding leaking any unfinished `yaml`s
3. Ensures that `config-locales` is the ONLY place to determine the app's locale tree

I am happy to go the other way around and favour convention over configuration, but I think we should pick one.