### PR TITLE
chore(project template): remove pageSlug from page props

### DIFF
--- a/cli/templates/project/src/context/locale-context.js
+++ b/cli/templates/project/src/context/locale-context.js
@@ -10,7 +10,7 @@ import { SiteStateContext } from "@local/context"
  */
 export const LocaleContext = createContext()
 
-export function LocaleProvider({ children, locale, pageSlug }) {
+export function LocaleProvider({ children, locale }) {
   const [localeCache, setCache] = useState()
   const { addPage } = useContext(SiteStateContext)
 

--- a/cli/templates/project/src/utils/page-setup.js
+++ b/cli/templates/project/src/utils/page-setup.js
@@ -64,14 +64,9 @@ export async function setupProps(ctx, pageName) {
 
   alternativeLocales = getAvailableLocales(pageName).filter((d) => d !== locale) || []
 
-  // Plucking out a "slug" for omniture tracking
-  const pageNameParts = pageName ? pageName.split("/") : ["home"]
-  const pageSlug = pageNameParts[pageNameParts.length - 1]
-
   return {
     props: {
       version: require("../../package.json")?.version || 0,
-      pageSlug,
       localeData: {
         pageName: pageName || null,
         locale,


### PR DESCRIPTION
# What
Removes the `pageSlug` variable from a page's props. 

## Why
This variable was added a long time ago, for some project-specific needs, and it does not warrant being part of the framework.





