### PR TITLE
refactor(CLI): make kebab case converter more robust

### DIFF
--- a/cli/lib/check-existing.js
+++ b/cli/lib/check-existing.js
@@ -2,12 +2,12 @@ import { existsSync } from "fs";
 
 import log from "./log.js"
 import prompt from "./prompt.js";
-import { getQuestion, pascalToKebab } from "./utils.js";
+import { getQuestion, makeKebabCase } from "./utils.js";
 
 // Async iterator lets us wait for the user's input on each question
 async function* askQuestions(dirNames, type) {
   for (const name of dirNames) {
-    const slug = pascalToKebab(name);
+    const slug = makeKebabCase(name);
 
     if (existsSync(`${type.location}/${slug}`)) {
       const input = await prompt(

--- a/cli/lib/utils.js
+++ b/cli/lib/utils.js
@@ -3,8 +3,12 @@ import CONSTS from "../consts.js";
 export const getQuestion = (id) =>
   CONSTS.QUESTIONS.find((q) => q.id === id).text;
 
-export const pascalToKebab = (str) =>
-  str.replace(/([a-z0–9])([A-Z])/g, "$1-$2").toLowerCase();
+// Very thorough kebab-casing regex replacer from StackOverflow user ABabin:
+// https://stackoverflow.com/a/67243723
+export const makeKebabCase = (str) => str.replace(
+  /[A-Z]+(?![a-z])|[A-Z]/g,
+  (match, offset) => (offset ? "-" : "") + match.toLowerCase()
+)
 
 const throwDirectoryPathError = (arg, example) => {
   throw new Error(
@@ -18,7 +22,7 @@ export const assembleDirectoryPath = ({ pathToDir, inputName } = {}) => {
 
   const parts = inputName.split("/");
   const name = parts.pop();
-  const slug = pascalToKebab(name);
+  const slug = makeKebabCase(name);
   const subDirectory = parts.join("/");
 
   const directory = `${pathToDir}/${subDirectory ? subDirectory + "/" : ""}${slug}`


### PR DESCRIPTION
# Goal
Ensure component names are parsed into kebab-case "slugs" as expected. For example, `FAQSection` should now return `faq-section`.

## Does this fix any existing issues?
Fixes #66 

## Testing locally
- clone this repo and check out the `bugfix/cli-parse-kebab-case` branch.
- run `node cli/bin/index.js project test-kebab-casing`
- run `cd test-kebab-casing`
- run `node ../cli/bin/index.js page FAQSection`
- Note the name of the resulting page directory is `faq-section`.