### PR TITLE
Fix: add correct "next steps" instructions

### DIFF
--- a/cli/lib/print-next-steps.js
+++ b/cli/lib/print-next-steps.js
@@ -9,7 +9,7 @@ const printNextSteps = (dir) => {
     "msg",
     `\nTo get started, run: \n${cdInstruction}\nnvm use ${chalk.dim(
       "(if using nvm)"
-    )} \nnpm install \nnpm start`
+    )} \nnpm install \nnpm run dev`
   );
 };
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/corgi",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Command line interface for use with the corgi framework.",
   "main": "bin/index.js",
   "bin": {

--- a/cli/templates/project/README.md
+++ b/cli/templates/project/README.md
@@ -8,7 +8,7 @@ Check out the official [corgi documentation](https://wethegit.github.io/corgi/) 
 ```bash
 nvm use
 npm install
-npm start
+npm run dev
 ```
 
 ## Build for production

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
     },
     "cli": {
       "name": "@wethegit/corgi",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "~5.0.1",


### PR DESCRIPTION
This updates the CLI's post-boostrapping message to print the correct npm script for local development (`npm run dev`). Also updated the project template's README.