### PR TITLE
fix: remove main tag from home body causing duplicate main tags in DOM

### DIFF
--- a/cli/templates/project/src/layouts/home/components/home-body/home-body.jsx
+++ b/cli/templates/project/src/layouts/home/components/home-body/home-body.jsx
@@ -9,7 +9,7 @@ export function HomeBody() {
   } = useLocale()
 
   return (
-    <main>
+    <>
       <h2>
         locale: <code>{locale}</code>
       </h2>
@@ -29,6 +29,6 @@ export function HomeBody() {
       <p>{coolSetting}</p>
 
       <p>{pageCoolSetting}</p>
-    </main>
+    </>
   )
 }


### PR DESCRIPTION
addresses issue in the `corgi-private-templates` repo https://github.com/wethegit/corgi-private-templates/issues/26

removing the inner duplicate to maintain the anchor link attached to `#main-content` 