### PR TITLE
Fix Safari issue with undefined locale

### DIFF
--- a/cli/templates/project/src/context/locale-context.jsx
+++ b/cli/templates/project/src/context/locale-context.jsx
@@ -20,6 +20,8 @@ export function LocaleProvider({ children, locale }) {
   }, [locale])
 
   useEffect(() => {
+    if (!locale) return
+    
     addPage(locale.pageName)
 
     setCache((cur) => {


### PR DESCRIPTION
# What does this do?
This PR fixes an issue with Safari 17, where the locale object is undefined on first render. It throws a TypeError and breaks the page.

## Solution
Add an early-exit condition if the locale is not defined, so the locale cache is not written to.

## Screenshot of error
![image](https://github.com/wethegit/corgi/assets/30575213/362a04eb-cd23-477e-adca-f2be68b76cf0)
