### PR TITLE
Release/2024 03 11

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/corgi",
-  "version": "3.0.17",
+  "version": "3.0.18",
   "description": "Command line interface for use with the corgi framework.",
   "main": "bin/index.js",
   "bin": {

--- a/cli/templates/project/src/context/locale-context.jsx
+++ b/cli/templates/project/src/context/locale-context.jsx
@@ -20,6 +20,8 @@ export function LocaleProvider({ children, locale }) {
   }, [locale])
 
   useEffect(() => {
+    if (!locale) return
+    
     addPage(locale.pageName)
 
     setCache((cur) => {

--- a/cli/templates/project/src/layouts/home/components/home-body/home-body.jsx
+++ b/cli/templates/project/src/layouts/home/components/home-body/home-body.jsx
@@ -9,7 +9,7 @@ export function HomeBody() {
   } = useLocale()
 
   return (
-    <main>
+    <>
       <h2>
         locale: <code>{locale}</code>
       </h2>
@@ -29,6 +29,6 @@ export function HomeBody() {
       <p>{coolSetting}</p>
 
       <p>{pageCoolSetting}</p>
-    </main>
+    </>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
     },
     "cli": {
       "name": "@wethegit/corgi",
-      "version": "3.0.10",
+      "version": "3.0.17",
       "license": "MIT",
       "dependencies": {
         "chalk": "~5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
     },
     "cli": {
       "name": "@wethegit/corgi",
-      "version": "3.0.17",
+      "version": "3.0.18",
       "license": "MIT",
       "dependencies": {
         "chalk": "~5.0.1",


### PR DESCRIPTION
### Changes include:
- CLI project template
  - Safari fix for undefined locale
  - Removal of unnecessary `<main>` tag which was conflicting with private templates we use
- CLI: bump version