### PR TITLE
feature: adds lint staged

### DIFF
--- a/cli/templates/project/.husky/pre-commit
+++ b/cli/templates/project/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/cli/templates/project/package.json
+++ b/cli/templates/project/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "build": "next build",
     "start": "next dev -p 8080",
-    "preview": "serve ./out -p 8080"
+    "preview": "serve ./out -p 8080",
+    "prepare": "husky"
   },
   "devDependencies": {
     "eslint": "~8.56.0",
@@ -18,7 +19,9 @@
     "stylelint": "~16.1.0",
     "stylelint-config-standard-scss": "~13.0.0",
     "stylelint-order": "~6.0.4",
-    "yamljs": "~0.3.0"
+    "yamljs": "~0.3.0",
+    "husky": "~9.0.11",
+    "lint-staged": "~15.2.2"
   },
   "dependencies": {
     "@wethegit/react-hooks": "~2.0.0",
@@ -27,5 +30,18 @@
     "next-compose-plugins": "~2.2.1",
     "react": "~18.2.0",
     "react-dom": "~18.2.0"
+  },
+  "lint-staged": {
+    "*.{jsx,js,ts,tsx}": [
+      "prettier --write",
+      "eslint --fix"
+    ],
+    "*.{css,scss}": [
+      "prettier --write",
+      "stylelint --fix"
+    ],
+    "*.{yaml,yml,json,md,html}": [
+      "prettier --write"
+    ]
   }
 }


### PR DESCRIPTION
# Description

Adds `lint-staged` as default project template.  
Yes, we want that in EVERY project so we can minimize build-time errors as much as possible.