### PR TITLE
fix(CLI): ensure component lib CLI outputs correct instructions

### DIFF
--- a/cli/lib/print-next-steps.js
+++ b/cli/lib/print-next-steps.js
@@ -12,7 +12,7 @@ const printNextSteps = (dir, componentsList) => {
   )} \n- npm install`
 
   if (componentsList.length) {
-    logMessage += ` \n\n🧩 Looks like this template requires components from ${chalk.bold("@wethegit/component-library")}. \nAfter installing dependencies run: \n- npx components-cli init \n- npx components-cli add ${componentsList.join(' ')}\n`
+    logMessage += ` \n\n🧩 Looks like this template requires components from ${chalk.bold("@wethegit/component-library")}. \nAfter installing dependencies run: \n- npx @wethegit/components-cli init \n- npx @wethegit/components-cli add ${componentsList.join(' ')}\n`
   }
 
   logMessage += `\n- npm start`;


### PR DESCRIPTION
## Description
The instructions for initializing the wethegit component library are missing the @wethegit namespace

## Solution
Change the messaging to point to `npx @wethegit/component-library init` (and `add`).

## Does this fix any open issues?
Closes #108 