### PR TITLE
fix(CLI templates): update project readme with correct local dev command

### DIFF
--- a/cli/templates/project/README.md
+++ b/cli/templates/project/README.md
@@ -8,7 +8,7 @@ Check out the official [corgi documentation](https://wethegit.github.io/corgi/) 
 ```bash
 nvm use
 npm install
-npm run dev
+npm start
 ```
 
 ## Build for production


### PR DESCRIPTION
## Description
The `Project readme` that comes along with a bootstrapped corgi project has some bad intel re: running a project locally.

## Solution
Changed this to `npm start`

Does this fix any open issues?
Closes #109 