### PR TITLE
Fix [project template] incorrect HTML lang attribute

### DIFF
--- a/cli/templates/project/src/pages/_document.jsx
+++ b/cli/templates/project/src/pages/_document.jsx
@@ -11,9 +11,11 @@ import { defaultLocale } from "@local/config-locales"
  * For importing third-party scripts, see the next/script docs:
  * https://nextjs.org/docs/basic-features/script
  */
-export default function Document() {
+export default function Document({ __NEXT_DATA__ }) {
+  const currentLocale = __NEXT_DATA__?.props?.pageProps?.localeData?.locale
+
   return (
-    <Html lang={defaultLocale}>
+    <Html lang={localeMap[currentLocale || defaultLocale].language}>
       <Head>
         <meta content="website" property="og:type" />
         <meta


### PR DESCRIPTION
# What does this solve?
This PR fixes the issue of the html tag's `lang` attribute always being set to the default locale's value.

## What was changed?
We're now pulling `pageProps` from within `_document.js`, in order to derive the current locale's slug at such a high level. This is then used as the priority when checking for the `language` string value. It will fall back to the default locale if undefined.

### Notes
- I'm grabbing the `__NEXT_DATA__` prop from the `Document` component, in order to pull this value. This _seems_ to be fine, but please chime in if you disagree.
- Fixes #121 

## Screencap
existing dev site vs. local (current change)

## Testing this change
- pull the `bugfix/html-lang-attr` branch down
- from within the repo's root directory, run the following command: `node ./bin/index.js project testing-html-lang`
- follow the instructions provided by the corgi CLI output, to get the project running.