### PR TITLE
HomeHeader: Remove non-existent spacing utils

### DIFF
--- a/cli/templates/project/src/layouts/home/components/home-header/home-header.jsx
+++ b/cli/templates/project/src/layouts/home/components/home-header/home-header.jsx
@@ -4,9 +4,8 @@ export function HomeHeader() {
   const { page } = useLocale()
 
   return (
-    <header className="content-spacing">
-      <h1 className="margin-bottom-2 margin-bottom-large-2">{page.title}</h1>
-
+    <header>
+      <h1>{page.title}</h1>
       <p>{page.subtitle}</p>
     </header>
   )


### PR DESCRIPTION
## Description

This simply removes some left-over CSS classnames which added various margin values to the `<HomeHeader>` component. Since the latest major corgi update, style opinions like this are no longer relevant.