### PR TITLE
Upgrade @wethegit/react-hooks

### DIFF
--- a/cli/templates/project/package.json
+++ b/cli/templates/project/package.json
@@ -24,7 +24,7 @@
     "lint-staged": "~15.2.2"
   },
   "dependencies": {
-    "@wethegit/react-hooks": "~2.0.0",
+    "@wethegit/react-hooks": "~3.0.1",
     "js-yaml-loader": "~1.2.2",
     "next": "~14.2.3",
     "next-compose-plugins": "~2.2.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,7 +17,7 @@
     "@docusaurus/core": "~3.3.2",
     "@docusaurus/preset-classic": "~3.3.2",
     "@emotion/react": "~11.11.4",
-    "@emotion/styled": "~11.10.5",
+    "@emotion/styled": "~11.11.5",
     "@mdx-js/react": "^1.6.22",
     "@mui/icons-material": "~5.15.18",
     "clsx": "^2.1.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "~3.4.0",
-    "@docusaurus/preset-classic": "~3.3.2",
+    "@docusaurus/preset-classic": "~3.4.0",
     "@emotion/react": "~11.11.4",
     "@emotion/styled": "~11.11.5",
     "@mdx-js/react": "^1.6.22",

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "~3.3.2",
+    "@docusaurus/core": "~3.4.0",
     "@docusaurus/preset-classic": "~3.3.2",
     "@emotion/react": "~11.11.4",
     "@emotion/styled": "~11.11.5",

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,7 +26,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.3.2"
+    "@docusaurus/module-type-aliases": "3.4.0"
   },
   "browserslist": {
     "production": [

--- a/docs/package.json
+++ b/docs/package.json
@@ -22,7 +22,7 @@
     "@mui/icons-material": "~5.15.18",
     "clsx": "^2.1.1",
     "prism-react-renderer": "^2.3.1",
-    "react": "^17.0.2",
+    "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,7 +19,7 @@
     "@emotion/react": "~11.11.4",
     "@emotion/styled": "~11.11.5",
     "@mdx-js/react": "^1.6.22",
-    "@mui/icons-material": "~5.15.18",
+    "@mui/icons-material": "~5.15.19",
     "clsx": "^2.1.1",
     "prism-react-renderer": "^2.3.1",
     "react": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@docusaurus/core": "~3.3.2",
         "@docusaurus/preset-classic": "~3.3.2",
         "@emotion/react": "~11.11.4",
-        "@emotion/styled": "~11.10.5",
+        "@emotion/styled": "~11.11.5",
         "@mdx-js/react": "^1.6.22",
         "@mui/icons-material": "~5.15.18",
         "clsx": "^2.1.1",
@@ -3321,9 +3321,9 @@
       "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
-      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
       "dependencies": {
         "@emotion/memoize": "^0.8.1"
       }
@@ -3357,9 +3357,9 @@
       }
     },
     "node_modules/@emotion/serialize": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.3.tgz",
-      "integrity": "sha512-iD4D6QVZFDhcbH0RAG1uVu1CwVLMWUkCvAqqlewO/rxf8+87yIBAlt4+AxMiiKPLs5hFc0owNk/sLLAOROw3cA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.4.tgz",
+      "integrity": "sha512-RIN04MBT8g+FnDwgvIUi8czvr1LU1alUMI05LekWB5DGyTm8cCBMCRpq3GqaiyEDRptEXOyXnvZ58GZYu4kBxQ==",
       "dependencies": {
         "@emotion/hash": "^0.9.1",
         "@emotion/memoize": "^0.8.1",
@@ -3374,16 +3374,16 @@
       "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
     },
     "node_modules/@emotion/styled": {
-      "version": "11.10.8",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.10.8.tgz",
-      "integrity": "sha512-gow0lF4Uw/QEdX2REMhI8v6wLOabPKJ+4HKNF0xdJ2DJdznN6fxaXpQOx6sNkyBhSUL558Rmcu1Lq/MYlVo4vw==",
+      "version": "11.11.5",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.5.tgz",
+      "integrity": "sha512-/ZjjnaNKvuMPxcIiUkf/9SHoG4Q196DRl1w82hQ3WCsjo1IUR8uaGWrC6a87CrYAW0Kb/pK7hk8BnLgLRi9KoQ==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.10.8",
-        "@emotion/is-prop-valid": "^1.2.0",
-        "@emotion/serialize": "^1.1.1",
-        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
-        "@emotion/utils": "^1.2.0"
+        "@emotion/babel-plugin": "^11.11.0",
+        "@emotion/is-prop-valid": "^1.2.2",
+        "@emotion/serialize": "^1.1.4",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+        "@emotion/utils": "^1.2.1"
       },
       "peerDependencies": {
         "@emotion/react": "^11.0.0-rc.0",
@@ -18208,9 +18208,9 @@
       "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
     },
     "@emotion/is-prop-valid": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
-      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
       "requires": {
         "@emotion/memoize": "^0.8.1"
       }
@@ -18236,9 +18236,9 @@
       }
     },
     "@emotion/serialize": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.3.tgz",
-      "integrity": "sha512-iD4D6QVZFDhcbH0RAG1uVu1CwVLMWUkCvAqqlewO/rxf8+87yIBAlt4+AxMiiKPLs5hFc0owNk/sLLAOROw3cA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.4.tgz",
+      "integrity": "sha512-RIN04MBT8g+FnDwgvIUi8czvr1LU1alUMI05LekWB5DGyTm8cCBMCRpq3GqaiyEDRptEXOyXnvZ58GZYu4kBxQ==",
       "requires": {
         "@emotion/hash": "^0.9.1",
         "@emotion/memoize": "^0.8.1",
@@ -18253,16 +18253,16 @@
       "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
     },
     "@emotion/styled": {
-      "version": "11.10.8",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.10.8.tgz",
-      "integrity": "sha512-gow0lF4Uw/QEdX2REMhI8v6wLOabPKJ+4HKNF0xdJ2DJdznN6fxaXpQOx6sNkyBhSUL558Rmcu1Lq/MYlVo4vw==",
+      "version": "11.11.5",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.5.tgz",
+      "integrity": "sha512-/ZjjnaNKvuMPxcIiUkf/9SHoG4Q196DRl1w82hQ3WCsjo1IUR8uaGWrC6a87CrYAW0Kb/pK7hk8BnLgLRi9KoQ==",
       "requires": {
         "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.10.8",
-        "@emotion/is-prop-valid": "^1.2.0",
-        "@emotion/serialize": "^1.1.1",
-        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
-        "@emotion/utils": "^1.2.0"
+        "@emotion/babel-plugin": "^11.11.0",
+        "@emotion/is-prop-valid": "^1.2.2",
+        "@emotion/serialize": "^1.1.4",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+        "@emotion/utils": "^1.2.1"
       }
     },
     "@emotion/unitless": {
@@ -19397,7 +19397,7 @@
         "@docusaurus/module-type-aliases": "3.3.2",
         "@docusaurus/preset-classic": "~3.3.2",
         "@emotion/react": "~11.11.4",
-        "@emotion/styled": "~11.10.5",
+        "@emotion/styled": "~11.11.5",
         "@mdx-js/react": "^1.6.22",
         "@mui/icons-material": "~5.15.18",
         "clsx": "^2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@emotion/react": "~11.11.4",
         "@emotion/styled": "~11.11.5",
         "@mdx-js/react": "^1.6.22",
-        "@mui/icons-material": "~5.15.18",
+        "@mui/icons-material": "~5.15.19",
         "clsx": "^2.1.1",
         "prism-react-renderer": "^2.3.1",
         "react": "^18.3.1",
@@ -3918,9 +3918,9 @@
       }
     },
     "node_modules/@mui/icons-material": {
-      "version": "5.15.18",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.15.18.tgz",
-      "integrity": "sha512-jGhyw02TSLM0NgW+MDQRLLRUD/K4eN9rlK2pTBTL1OtzyZmQ8nB060zK1wA0b7cVrIiG+zyrRmNAvGWXwm2N9Q==",
+      "version": "5.15.19",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.15.19.tgz",
+      "integrity": "sha512-RsEiRxA5azN9b8gI7JRqekkgvxQUlitoBOtZglflb8cUDyP12/cP4gRwhb44Ea1/zwwGGjAj66ZJpGHhKfibNA==",
       "dependencies": {
         "@babel/runtime": "^7.23.9"
       },
@@ -18872,9 +18872,9 @@
       "peer": true
     },
     "@mui/icons-material": {
-      "version": "5.15.18",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.15.18.tgz",
-      "integrity": "sha512-jGhyw02TSLM0NgW+MDQRLLRUD/K4eN9rlK2pTBTL1OtzyZmQ8nB060zK1wA0b7cVrIiG+zyrRmNAvGWXwm2N9Q==",
+      "version": "5.15.19",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.15.19.tgz",
+      "integrity": "sha512-RsEiRxA5azN9b8gI7JRqekkgvxQUlitoBOtZglflb8cUDyP12/cP4gRwhb44Ea1/zwwGGjAj66ZJpGHhKfibNA==",
       "requires": {
         "@babel/runtime": "^7.23.9"
       }
@@ -19764,7 +19764,7 @@
         "@emotion/react": "~11.11.4",
         "@emotion/styled": "~11.11.5",
         "@mdx-js/react": "^1.6.22",
-        "@mui/icons-material": "~5.15.18",
+        "@mui/icons-material": "~5.15.19",
         "clsx": "^2.1.1",
         "prism-react-renderer": "^2.3.1",
         "react": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
       "name": "@wethegit/corgi-docs",
       "version": "1.0.1",
       "dependencies": {
-        "@docusaurus/core": "~3.3.2",
+        "@docusaurus/core": "~3.4.0",
         "@docusaurus/preset-classic": "~3.3.2",
         "@emotion/react": "~11.11.4",
         "@emotion/styled": "~11.11.5",
@@ -2218,9 +2218,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.3.2.tgz",
-      "integrity": "sha512-PzKMydKI3IU1LmeZQDi+ut5RSuilbXnA8QdowGeJEgU8EJjmx3rBHNT1LxQxOVqNEwpWi/csLwd9bn7rUjggPA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-g+0wwmN2UJsBqy2fQRQ6fhXruoEa62JDeEa5d8IdTJlMoaDaEDfHh7WjwGRn4opuTQWpjAwP/fbcgyHKlE+64w==",
       "dependencies": {
         "@babel/core": "^7.23.3",
         "@babel/generator": "^7.23.3",
@@ -2232,12 +2232,12 @@
         "@babel/runtime": "^7.22.6",
         "@babel/runtime-corejs3": "^7.22.6",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.3.2",
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/cssnano-preset": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "autoprefixer": "^10.4.14",
         "babel-loader": "^9.1.3",
         "babel-plugin-dynamic-import-node": "^2.3.3",
@@ -2302,98 +2302,34 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/core/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.3.2.tgz",
-      "integrity": "sha512-AFRxj/aOk3/mfYDPxE3wTbrjeayVRvNSZP7mgMuUlrb2UlPRbSVAFX1k2RbgAJrnTSwMgb92m2BhJgYRfptN3g==",
+    "node_modules/@docusaurus/core/node_modules/@docusaurus/logger": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.4.0.tgz",
+      "integrity": "sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==",
       "dependencies": {
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/core/node_modules/@docusaurus/utils": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.3.2.tgz",
-      "integrity": "sha512-f4YMnBVymtkSxONv4Y8js3Gez9IgHX+Lcg6YRMOjVbq8sgCcdYK1lf6SObAuz5qB/mxiSK7tW0M9aaiIaUSUJg==",
-      "dependencies": {
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@svgr/webpack": "^8.1.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/core/node_modules/@docusaurus/utils-common": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.3.2.tgz",
-      "integrity": "sha512-QWFTLEkPYsejJsLStgtmetMFIA3pM8EPexcZ4WZ7b++gO5jGVH7zsipREnCHzk6+eDgeaXfkR6UPaTt86bp8Og==",
-      "dependencies": {
+        "chalk": "^4.1.2",
         "tslib": "^2.6.0"
       },
       "engines": {
         "node": ">=18.0"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/@docusaurus/utils-validation": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.4.0.tgz",
+      "integrity": "sha512-hYQ9fM+AXYVTWxJOT1EuNaRnrR2WGpRdLDQG07O8UOpsvCPWUVOeo26Rbm0JWY2sGLfzAb+tvJ62yF+8F+TV0g==",
+      "dependencies": {
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "fs-extra": "^11.2.0",
+        "joi": "^17.9.2",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
       },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">=18.0"
       }
     },
     "node_modules/@docusaurus/core/node_modules/ansi-styles": {
@@ -2489,9 +2425,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.3.2.tgz",
-      "integrity": "sha512-+5+epLk/Rp4vFML4zmyTATNc3Is+buMAL6dNjrMWahdJCJlMWMPd/8YfU+2PA57t8mlSbhLJ7vAZVy54cd1vRQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.4.0.tgz",
+      "integrity": "sha512-qwLFSz6v/pZHy/UP32IrprmH5ORce86BGtN0eBtG75PpzQJAzp9gefspox+s8IEOr0oZKuQ/nhzZ3xwyc3jYJQ==",
       "dependencies": {
         "cssnano-preset-advanced": "^6.1.2",
         "postcss": "^8.4.38",
@@ -2570,6 +2506,130 @@
         "node": ">=8"
       }
     },
+    "node_modules/@docusaurus/mdx-loader": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.4.0.tgz",
+      "integrity": "sha512-kSSbrrk4nTjf4d+wtBA9H+FGauf2gCax89kV8SUSJu3qaTdSIKdWERlngsiHaCFgZ7laTJ8a67UFf+xlFPtuTw==",
+      "dependencies": {
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
+        "@mdx-js/mdx": "^3.0.0",
+        "@slorber/remark-comment": "^1.0.0",
+        "escape-html": "^1.0.3",
+        "estree-util-value-to-estree": "^3.0.1",
+        "file-loader": "^6.2.0",
+        "fs-extra": "^11.1.1",
+        "image-size": "^1.0.2",
+        "mdast-util-mdx": "^3.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "rehype-raw": "^7.0.0",
+        "remark-directive": "^3.0.0",
+        "remark-emoji": "^4.0.0",
+        "remark-frontmatter": "^5.0.0",
+        "remark-gfm": "^4.0.0",
+        "stringify-object": "^3.3.0",
+        "tslib": "^2.6.0",
+        "unified": "^11.0.3",
+        "unist-util-visit": "^5.0.0",
+        "url-loader": "^4.1.1",
+        "vfile": "^6.0.1",
+        "webpack": "^5.88.1"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@docusaurus/mdx-loader/node_modules/@docusaurus/logger": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.4.0.tgz",
+      "integrity": "sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@docusaurus/mdx-loader/node_modules/@docusaurus/utils-validation": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.4.0.tgz",
+      "integrity": "sha512-hYQ9fM+AXYVTWxJOT1EuNaRnrR2WGpRdLDQG07O8UOpsvCPWUVOeo26Rbm0JWY2sGLfzAb+tvJ62yF+8F+TV0g==",
+      "dependencies": {
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "fs-extra": "^11.2.0",
+        "joi": "^17.9.2",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@docusaurus/mdx-loader/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@docusaurus/mdx-loader/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@docusaurus/mdx-loader/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@docusaurus/mdx-loader/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/@docusaurus/mdx-loader/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@docusaurus/module-type-aliases": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.3.2.tgz",
@@ -2615,28 +2675,82 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-content-blog": {
+    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/core": {
       "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.3.2.tgz",
-      "integrity": "sha512-fJU+dmqp231LnwDJv+BHVWft8pcUS2xVPZdeYH6/ibH1s2wQ/sLcmUrGWyIv/Gq9Ptj8XWjRPMghlxghuPPoxg==",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.3.2.tgz",
+      "integrity": "sha512-PzKMydKI3IU1LmeZQDi+ut5RSuilbXnA8QdowGeJEgU8EJjmx3rBHNT1LxQxOVqNEwpWi/csLwd9bn7rUjggPA==",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
+        "@babel/core": "^7.23.3",
+        "@babel/generator": "^7.23.3",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-transform-runtime": "^7.22.9",
+        "@babel/preset-env": "^7.22.9",
+        "@babel/preset-react": "^7.22.5",
+        "@babel/preset-typescript": "^7.22.5",
+        "@babel/runtime": "^7.22.6",
+        "@babel/runtime-corejs3": "^7.22.6",
+        "@babel/traverse": "^7.22.8",
+        "@docusaurus/cssnano-preset": "3.3.2",
         "@docusaurus/logger": "3.3.2",
         "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/types": "3.3.2",
         "@docusaurus/utils": "3.3.2",
         "@docusaurus/utils-common": "3.3.2",
         "@docusaurus/utils-validation": "3.3.2",
-        "cheerio": "^1.0.0-rc.12",
-        "feed": "^4.2.2",
+        "autoprefixer": "^10.4.14",
+        "babel-loader": "^9.1.3",
+        "babel-plugin-dynamic-import-node": "^2.3.3",
+        "boxen": "^6.2.1",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.5.3",
+        "clean-css": "^5.3.2",
+        "cli-table3": "^0.6.3",
+        "combine-promises": "^1.1.0",
+        "commander": "^5.1.0",
+        "copy-webpack-plugin": "^11.0.0",
+        "core-js": "^3.31.1",
+        "css-loader": "^6.8.1",
+        "css-minimizer-webpack-plugin": "^5.0.1",
+        "cssnano": "^6.1.2",
+        "del": "^6.1.1",
+        "detect-port": "^1.5.1",
+        "escape-html": "^1.0.3",
+        "eta": "^2.2.0",
+        "eval": "^0.1.8",
+        "file-loader": "^6.2.0",
         "fs-extra": "^11.1.1",
+        "html-minifier-terser": "^7.2.0",
+        "html-tags": "^3.3.1",
+        "html-webpack-plugin": "^5.5.3",
+        "leven": "^3.1.0",
         "lodash": "^4.17.21",
-        "reading-time": "^1.5.0",
-        "srcset": "^4.0.0",
+        "mini-css-extract-plugin": "^2.7.6",
+        "p-map": "^4.0.0",
+        "postcss": "^8.4.26",
+        "postcss-loader": "^7.3.3",
+        "prompts": "^2.4.2",
+        "react-dev-utils": "^12.0.1",
+        "react-helmet-async": "^1.3.0",
+        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
+        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+        "react-router": "^5.3.4",
+        "react-router-config": "^5.1.1",
+        "react-router-dom": "^5.3.4",
+        "rtl-detect": "^1.0.4",
+        "semver": "^7.5.4",
+        "serve-handler": "^6.1.5",
+        "shelljs": "^0.8.5",
+        "terser-webpack-plugin": "^5.3.9",
         "tslib": "^2.6.0",
-        "unist-util-visit": "^5.0.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
+        "update-notifier": "^6.0.2",
+        "url-loader": "^4.1.1",
+        "webpack": "^5.88.1",
+        "webpack-bundle-analyzer": "^4.9.0",
+        "webpack-dev-server": "^4.15.1",
+        "webpack-merge": "^5.9.0",
+        "webpackbar": "^5.0.2"
+      },
+      "bin": {
+        "docusaurus": "bin/docusaurus.mjs"
       },
       "engines": {
         "node": ">=18.0"
@@ -2646,7 +2760,21 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/mdx-loader": {
+    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/cssnano-preset": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.3.2.tgz",
+      "integrity": "sha512-+5+epLk/Rp4vFML4zmyTATNc3Is+buMAL6dNjrMWahdJCJlMWMPd/8YfU+2PA57t8mlSbhLJ7vAZVy54cd1vRQ==",
+      "dependencies": {
+        "cssnano-preset-advanced": "^6.1.2",
+        "postcss": "^8.4.38",
+        "postcss-sort-media-queries": "^5.2.0",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/mdx-loader": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.3.2.tgz",
       "integrity": "sha512-AFRxj/aOk3/mfYDPxE3wTbrjeayVRvNSZP7mgMuUlrb2UlPRbSVAFX1k2RbgAJrnTSwMgb92m2BhJgYRfptN3g==",
@@ -2674,6 +2802,37 @@
         "unist-util-visit": "^5.0.0",
         "url-loader": "^4.1.1",
         "vfile": "^6.0.1",
+        "webpack": "^5.88.1"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-content-blog": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.3.2.tgz",
+      "integrity": "sha512-fJU+dmqp231LnwDJv+BHVWft8pcUS2xVPZdeYH6/ibH1s2wQ/sLcmUrGWyIv/Gq9Ptj8XWjRPMghlxghuPPoxg==",
+      "dependencies": {
+        "@docusaurus/core": "3.3.2",
+        "@docusaurus/logger": "3.3.2",
+        "@docusaurus/mdx-loader": "3.3.2",
+        "@docusaurus/types": "3.3.2",
+        "@docusaurus/utils": "3.3.2",
+        "@docusaurus/utils-common": "3.3.2",
+        "@docusaurus/utils-validation": "3.3.2",
+        "cheerio": "^1.0.0-rc.12",
+        "feed": "^4.2.2",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "reading-time": "^1.5.0",
+        "srcset": "^4.0.0",
+        "tslib": "^2.6.0",
+        "unist-util-visit": "^5.0.0",
+        "utility-types": "^3.10.0",
         "webpack": "^5.88.1"
       },
       "engines": {
@@ -2714,44 +2873,6 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.3.2.tgz",
-      "integrity": "sha512-AFRxj/aOk3/mfYDPxE3wTbrjeayVRvNSZP7mgMuUlrb2UlPRbSVAFX1k2RbgAJrnTSwMgb92m2BhJgYRfptN3g==",
-      "dependencies": {
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
     "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-content-pages": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.3.2.tgz",
@@ -2764,44 +2885,6 @@
         "@docusaurus/utils-validation": "3.3.2",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.3.2.tgz",
-      "integrity": "sha512-AFRxj/aOk3/mfYDPxE3wTbrjeayVRvNSZP7mgMuUlrb2UlPRbSVAFX1k2RbgAJrnTSwMgb92m2BhJgYRfptN3g==",
-      "dependencies": {
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
         "webpack": "^5.88.1"
       },
       "engines": {
@@ -2949,44 +3032,6 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.3.2.tgz",
-      "integrity": "sha512-AFRxj/aOk3/mfYDPxE3wTbrjeayVRvNSZP7mgMuUlrb2UlPRbSVAFX1k2RbgAJrnTSwMgb92m2BhJgYRfptN3g==",
-      "dependencies": {
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
     "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/theme-common": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.3.2.tgz",
@@ -3007,44 +3052,6 @@
         "prism-react-renderer": "^2.3.0",
         "tslib": "^2.6.0",
         "utility-types": "^3.10.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/theme-common/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.3.2.tgz",
-      "integrity": "sha512-AFRxj/aOk3/mfYDPxE3wTbrjeayVRvNSZP7mgMuUlrb2UlPRbSVAFX1k2RbgAJrnTSwMgb92m2BhJgYRfptN3g==",
-      "dependencies": {
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
       },
       "engines": {
         "node": ">=18.0"
@@ -3156,6 +3163,98 @@
         "react": ">=16"
       }
     },
+    "node_modules/@docusaurus/preset-classic/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@docusaurus/preset-classic/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@docusaurus/preset-classic/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@docusaurus/preset-classic/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/@docusaurus/preset-classic/node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@docusaurus/preset-classic/node_modules/html-minifier-terser": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
+      "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "clean-css": "~5.3.2",
+        "commander": "^10.0.0",
+        "entities": "^4.4.0",
+        "param-case": "^3.0.4",
+        "relateurl": "^0.2.7",
+        "terser": "^5.15.1"
+      },
+      "bin": {
+        "html-minifier-terser": "cli.js"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/@docusaurus/preset-classic/node_modules/html-minifier-terser/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@docusaurus/preset-classic/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@docusaurus/theme-translations": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.3.2.tgz",
@@ -3194,6 +3293,63 @@
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@docusaurus/utils": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.4.0.tgz",
+      "integrity": "sha512-fRwnu3L3nnWaXOgs88BVBmG1yGjcQqZNHG+vInhEa2Sz2oQB+ZjbEMO5Rh9ePFpZ0YDiDUhpaVjwmS+AU2F14g==",
+      "dependencies": {
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@svgr/webpack": "^8.1.0",
+        "escape-string-regexp": "^4.0.0",
+        "file-loader": "^6.2.0",
+        "fs-extra": "^11.1.1",
+        "github-slugger": "^1.5.0",
+        "globby": "^11.1.0",
+        "gray-matter": "^4.0.3",
+        "jiti": "^1.20.0",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "micromatch": "^4.0.5",
+        "prompts": "^2.4.2",
+        "resolve-pathname": "^3.0.0",
+        "shelljs": "^0.8.5",
+        "tslib": "^2.6.0",
+        "url-loader": "^4.1.1",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/types": "*"
+      },
+      "peerDependenciesMeta": {
+        "@docusaurus/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@docusaurus/utils-common": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.4.0.tgz",
+      "integrity": "sha512-NVx54Wr4rCEKsjOH5QEVvxIqVvm+9kh7q8aYTU5WzUU9/Hctd6aTrcZ3G0Id4zYJ+AeaG5K5qHA4CY5Kcm2iyQ==",
+      "dependencies": {
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/types": "*"
+      },
+      "peerDependenciesMeta": {
+        "@docusaurus/types": {
+          "optional": true
+        }
       }
     },
     "node_modules/@docusaurus/utils-validation": {
@@ -3266,6 +3422,74 @@
         "@docusaurus/types": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@docusaurus/utils/node_modules/@docusaurus/logger": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.4.0.tgz",
+      "integrity": "sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@docusaurus/utils/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@docusaurus/utils/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@docusaurus/utils/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@docusaurus/utils/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/@docusaurus/utils/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -17361,9 +17585,9 @@
       }
     },
     "@docusaurus/core": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.3.2.tgz",
-      "integrity": "sha512-PzKMydKI3IU1LmeZQDi+ut5RSuilbXnA8QdowGeJEgU8EJjmx3rBHNT1LxQxOVqNEwpWi/csLwd9bn7rUjggPA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-g+0wwmN2UJsBqy2fQRQ6fhXruoEa62JDeEa5d8IdTJlMoaDaEDfHh7WjwGRn4opuTQWpjAwP/fbcgyHKlE+64w==",
       "requires": {
         "@babel/core": "^7.23.3",
         "@babel/generator": "^7.23.3",
@@ -17375,12 +17599,12 @@
         "@babel/runtime": "^7.22.6",
         "@babel/runtime-corejs3": "^7.22.6",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.3.2",
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/cssnano-preset": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "autoprefixer": "^10.4.14",
         "babel-loader": "^9.1.3",
         "babel-plugin-dynamic-import-node": "^2.3.3",
@@ -17435,68 +17659,27 @@
         "webpackbar": "^5.0.2"
       },
       "dependencies": {
-        "@docusaurus/mdx-loader": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.3.2.tgz",
-          "integrity": "sha512-AFRxj/aOk3/mfYDPxE3wTbrjeayVRvNSZP7mgMuUlrb2UlPRbSVAFX1k2RbgAJrnTSwMgb92m2BhJgYRfptN3g==",
+        "@docusaurus/logger": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.4.0.tgz",
+          "integrity": "sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==",
           "requires": {
-            "@docusaurus/logger": "3.3.2",
-            "@docusaurus/utils": "3.3.2",
-            "@docusaurus/utils-validation": "3.3.2",
-            "@mdx-js/mdx": "^3.0.0",
-            "@slorber/remark-comment": "^1.0.0",
-            "escape-html": "^1.0.3",
-            "estree-util-value-to-estree": "^3.0.1",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^11.1.1",
-            "image-size": "^1.0.2",
-            "mdast-util-mdx": "^3.0.0",
-            "mdast-util-to-string": "^4.0.0",
-            "rehype-raw": "^7.0.0",
-            "remark-directive": "^3.0.0",
-            "remark-emoji": "^4.0.0",
-            "remark-frontmatter": "^5.0.0",
-            "remark-gfm": "^4.0.0",
-            "stringify-object": "^3.3.0",
-            "tslib": "^2.6.0",
-            "unified": "^11.0.3",
-            "unist-util-visit": "^5.0.0",
-            "url-loader": "^4.1.1",
-            "vfile": "^6.0.1",
-            "webpack": "^5.88.1"
+            "chalk": "^4.1.2",
+            "tslib": "^2.6.0"
           }
         },
-        "@docusaurus/utils": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.3.2.tgz",
-          "integrity": "sha512-f4YMnBVymtkSxONv4Y8js3Gez9IgHX+Lcg6YRMOjVbq8sgCcdYK1lf6SObAuz5qB/mxiSK7tW0M9aaiIaUSUJg==",
+        "@docusaurus/utils-validation": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.4.0.tgz",
+          "integrity": "sha512-hYQ9fM+AXYVTWxJOT1EuNaRnrR2WGpRdLDQG07O8UOpsvCPWUVOeo26Rbm0JWY2sGLfzAb+tvJ62yF+8F+TV0g==",
           "requires": {
-            "@docusaurus/logger": "3.3.2",
-            "@docusaurus/utils-common": "3.3.2",
-            "@svgr/webpack": "^8.1.0",
-            "escape-string-regexp": "^4.0.0",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^11.1.1",
-            "github-slugger": "^1.5.0",
-            "globby": "^11.1.0",
-            "gray-matter": "^4.0.3",
-            "jiti": "^1.20.0",
+            "@docusaurus/logger": "3.4.0",
+            "@docusaurus/utils": "3.4.0",
+            "@docusaurus/utils-common": "3.4.0",
+            "fs-extra": "^11.2.0",
+            "joi": "^17.9.2",
             "js-yaml": "^4.1.0",
             "lodash": "^4.17.21",
-            "micromatch": "^4.0.5",
-            "prompts": "^2.4.2",
-            "resolve-pathname": "^3.0.0",
-            "shelljs": "^0.8.5",
-            "tslib": "^2.6.0",
-            "url-loader": "^4.1.1",
-            "webpack": "^5.88.1"
-          }
-        },
-        "@docusaurus/utils-common": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.3.2.tgz",
-          "integrity": "sha512-QWFTLEkPYsejJsLStgtmetMFIA3pM8EPexcZ4WZ7b++gO5jGVH7zsipREnCHzk6+eDgeaXfkR6UPaTt86bp8Og==",
-          "requires": {
             "tslib": "^2.6.0"
           }
         },
@@ -17567,9 +17750,9 @@
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.3.2.tgz",
-      "integrity": "sha512-+5+epLk/Rp4vFML4zmyTATNc3Is+buMAL6dNjrMWahdJCJlMWMPd/8YfU+2PA57t8mlSbhLJ7vAZVy54cd1vRQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.4.0.tgz",
+      "integrity": "sha512-qwLFSz6v/pZHy/UP32IrprmH5ORce86BGtN0eBtG75PpzQJAzp9gefspox+s8IEOr0oZKuQ/nhzZ3xwyc3jYJQ==",
       "requires": {
         "cssnano-preset-advanced": "^6.1.2",
         "postcss": "^8.4.38",
@@ -17586,6 +17769,101 @@
         "tslib": "^2.6.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@docusaurus/mdx-loader": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.4.0.tgz",
+      "integrity": "sha512-kSSbrrk4nTjf4d+wtBA9H+FGauf2gCax89kV8SUSJu3qaTdSIKdWERlngsiHaCFgZ7laTJ8a67UFf+xlFPtuTw==",
+      "requires": {
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
+        "@mdx-js/mdx": "^3.0.0",
+        "@slorber/remark-comment": "^1.0.0",
+        "escape-html": "^1.0.3",
+        "estree-util-value-to-estree": "^3.0.1",
+        "file-loader": "^6.2.0",
+        "fs-extra": "^11.1.1",
+        "image-size": "^1.0.2",
+        "mdast-util-mdx": "^3.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "rehype-raw": "^7.0.0",
+        "remark-directive": "^3.0.0",
+        "remark-emoji": "^4.0.0",
+        "remark-frontmatter": "^5.0.0",
+        "remark-gfm": "^4.0.0",
+        "stringify-object": "^3.3.0",
+        "tslib": "^2.6.0",
+        "unified": "^11.0.3",
+        "unist-util-visit": "^5.0.0",
+        "url-loader": "^4.1.1",
+        "vfile": "^6.0.1",
+        "webpack": "^5.88.1"
+      },
+      "dependencies": {
+        "@docusaurus/logger": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.4.0.tgz",
+          "integrity": "sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==",
+          "requires": {
+            "chalk": "^4.1.2",
+            "tslib": "^2.6.0"
+          }
+        },
+        "@docusaurus/utils-validation": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.4.0.tgz",
+          "integrity": "sha512-hYQ9fM+AXYVTWxJOT1EuNaRnrR2WGpRdLDQG07O8UOpsvCPWUVOeo26Rbm0JWY2sGLfzAb+tvJ62yF+8F+TV0g==",
+          "requires": {
+            "@docusaurus/logger": "3.4.0",
+            "@docusaurus/utils": "3.4.0",
+            "@docusaurus/utils-common": "3.4.0",
+            "fs-extra": "^11.2.0",
+            "joi": "^17.9.2",
+            "js-yaml": "^4.1.0",
+            "lodash": "^4.17.21",
+            "tslib": "^2.6.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -17660,6 +17938,123 @@
         "@docusaurus/types": "3.3.2"
       },
       "dependencies": {
+        "@docusaurus/core": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.3.2.tgz",
+          "integrity": "sha512-PzKMydKI3IU1LmeZQDi+ut5RSuilbXnA8QdowGeJEgU8EJjmx3rBHNT1LxQxOVqNEwpWi/csLwd9bn7rUjggPA==",
+          "requires": {
+            "@babel/core": "^7.23.3",
+            "@babel/generator": "^7.23.3",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+            "@babel/plugin-transform-runtime": "^7.22.9",
+            "@babel/preset-env": "^7.22.9",
+            "@babel/preset-react": "^7.22.5",
+            "@babel/preset-typescript": "^7.22.5",
+            "@babel/runtime": "^7.22.6",
+            "@babel/runtime-corejs3": "^7.22.6",
+            "@babel/traverse": "^7.22.8",
+            "@docusaurus/cssnano-preset": "3.3.2",
+            "@docusaurus/logger": "3.3.2",
+            "@docusaurus/mdx-loader": "3.3.2",
+            "@docusaurus/utils": "3.3.2",
+            "@docusaurus/utils-common": "3.3.2",
+            "@docusaurus/utils-validation": "3.3.2",
+            "autoprefixer": "^10.4.14",
+            "babel-loader": "^9.1.3",
+            "babel-plugin-dynamic-import-node": "^2.3.3",
+            "boxen": "^6.2.1",
+            "chalk": "^4.1.2",
+            "chokidar": "^3.5.3",
+            "clean-css": "^5.3.2",
+            "cli-table3": "^0.6.3",
+            "combine-promises": "^1.1.0",
+            "commander": "^5.1.0",
+            "copy-webpack-plugin": "^11.0.0",
+            "core-js": "^3.31.1",
+            "css-loader": "^6.8.1",
+            "css-minimizer-webpack-plugin": "^5.0.1",
+            "cssnano": "^6.1.2",
+            "del": "^6.1.1",
+            "detect-port": "^1.5.1",
+            "escape-html": "^1.0.3",
+            "eta": "^2.2.0",
+            "eval": "^0.1.8",
+            "file-loader": "^6.2.0",
+            "fs-extra": "^11.1.1",
+            "html-minifier-terser": "^7.2.0",
+            "html-tags": "^3.3.1",
+            "html-webpack-plugin": "^5.5.3",
+            "leven": "^3.1.0",
+            "lodash": "^4.17.21",
+            "mini-css-extract-plugin": "^2.7.6",
+            "p-map": "^4.0.0",
+            "postcss": "^8.4.26",
+            "postcss-loader": "^7.3.3",
+            "prompts": "^2.4.2",
+            "react-dev-utils": "^12.0.1",
+            "react-helmet-async": "^1.3.0",
+            "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
+            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+            "react-router": "^5.3.4",
+            "react-router-config": "^5.1.1",
+            "react-router-dom": "^5.3.4",
+            "rtl-detect": "^1.0.4",
+            "semver": "^7.5.4",
+            "serve-handler": "^6.1.5",
+            "shelljs": "^0.8.5",
+            "terser-webpack-plugin": "^5.3.9",
+            "tslib": "^2.6.0",
+            "update-notifier": "^6.0.2",
+            "url-loader": "^4.1.1",
+            "webpack": "^5.88.1",
+            "webpack-bundle-analyzer": "^4.9.0",
+            "webpack-dev-server": "^4.15.1",
+            "webpack-merge": "^5.9.0",
+            "webpackbar": "^5.0.2"
+          }
+        },
+        "@docusaurus/cssnano-preset": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.3.2.tgz",
+          "integrity": "sha512-+5+epLk/Rp4vFML4zmyTATNc3Is+buMAL6dNjrMWahdJCJlMWMPd/8YfU+2PA57t8mlSbhLJ7vAZVy54cd1vRQ==",
+          "requires": {
+            "cssnano-preset-advanced": "^6.1.2",
+            "postcss": "^8.4.38",
+            "postcss-sort-media-queries": "^5.2.0",
+            "tslib": "^2.6.0"
+          }
+        },
+        "@docusaurus/mdx-loader": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.3.2.tgz",
+          "integrity": "sha512-AFRxj/aOk3/mfYDPxE3wTbrjeayVRvNSZP7mgMuUlrb2UlPRbSVAFX1k2RbgAJrnTSwMgb92m2BhJgYRfptN3g==",
+          "requires": {
+            "@docusaurus/logger": "3.3.2",
+            "@docusaurus/utils": "3.3.2",
+            "@docusaurus/utils-validation": "3.3.2",
+            "@mdx-js/mdx": "^3.0.0",
+            "@slorber/remark-comment": "^1.0.0",
+            "escape-html": "^1.0.3",
+            "estree-util-value-to-estree": "^3.0.1",
+            "file-loader": "^6.2.0",
+            "fs-extra": "^11.1.1",
+            "image-size": "^1.0.2",
+            "mdast-util-mdx": "^3.0.0",
+            "mdast-util-to-string": "^4.0.0",
+            "rehype-raw": "^7.0.0",
+            "remark-directive": "^3.0.0",
+            "remark-emoji": "^4.0.0",
+            "remark-frontmatter": "^5.0.0",
+            "remark-gfm": "^4.0.0",
+            "stringify-object": "^3.3.0",
+            "tslib": "^2.6.0",
+            "unified": "^11.0.3",
+            "unist-util-visit": "^5.0.0",
+            "url-loader": "^4.1.1",
+            "vfile": "^6.0.1",
+            "webpack": "^5.88.1"
+          }
+        },
         "@docusaurus/plugin-content-blog": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.3.2.tgz",
@@ -17682,39 +18077,6 @@
             "unist-util-visit": "^5.0.0",
             "utility-types": "^3.10.0",
             "webpack": "^5.88.1"
-          },
-          "dependencies": {
-            "@docusaurus/mdx-loader": {
-              "version": "3.3.2",
-              "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.3.2.tgz",
-              "integrity": "sha512-AFRxj/aOk3/mfYDPxE3wTbrjeayVRvNSZP7mgMuUlrb2UlPRbSVAFX1k2RbgAJrnTSwMgb92m2BhJgYRfptN3g==",
-              "requires": {
-                "@docusaurus/logger": "3.3.2",
-                "@docusaurus/utils": "3.3.2",
-                "@docusaurus/utils-validation": "3.3.2",
-                "@mdx-js/mdx": "^3.0.0",
-                "@slorber/remark-comment": "^1.0.0",
-                "escape-html": "^1.0.3",
-                "estree-util-value-to-estree": "^3.0.1",
-                "file-loader": "^6.2.0",
-                "fs-extra": "^11.1.1",
-                "image-size": "^1.0.2",
-                "mdast-util-mdx": "^3.0.0",
-                "mdast-util-to-string": "^4.0.0",
-                "rehype-raw": "^7.0.0",
-                "remark-directive": "^3.0.0",
-                "remark-emoji": "^4.0.0",
-                "remark-frontmatter": "^5.0.0",
-                "remark-gfm": "^4.0.0",
-                "stringify-object": "^3.3.0",
-                "tslib": "^2.6.0",
-                "unified": "^11.0.3",
-                "unist-util-visit": "^5.0.0",
-                "url-loader": "^4.1.1",
-                "vfile": "^6.0.1",
-                "webpack": "^5.88.1"
-              }
-            }
           }
         },
         "@docusaurus/plugin-content-docs": {
@@ -17738,39 +18100,6 @@
             "tslib": "^2.6.0",
             "utility-types": "^3.10.0",
             "webpack": "^5.88.1"
-          },
-          "dependencies": {
-            "@docusaurus/mdx-loader": {
-              "version": "3.3.2",
-              "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.3.2.tgz",
-              "integrity": "sha512-AFRxj/aOk3/mfYDPxE3wTbrjeayVRvNSZP7mgMuUlrb2UlPRbSVAFX1k2RbgAJrnTSwMgb92m2BhJgYRfptN3g==",
-              "requires": {
-                "@docusaurus/logger": "3.3.2",
-                "@docusaurus/utils": "3.3.2",
-                "@docusaurus/utils-validation": "3.3.2",
-                "@mdx-js/mdx": "^3.0.0",
-                "@slorber/remark-comment": "^1.0.0",
-                "escape-html": "^1.0.3",
-                "estree-util-value-to-estree": "^3.0.1",
-                "file-loader": "^6.2.0",
-                "fs-extra": "^11.1.1",
-                "image-size": "^1.0.2",
-                "mdast-util-mdx": "^3.0.0",
-                "mdast-util-to-string": "^4.0.0",
-                "rehype-raw": "^7.0.0",
-                "remark-directive": "^3.0.0",
-                "remark-emoji": "^4.0.0",
-                "remark-frontmatter": "^5.0.0",
-                "remark-gfm": "^4.0.0",
-                "stringify-object": "^3.3.0",
-                "tslib": "^2.6.0",
-                "unified": "^11.0.3",
-                "unist-util-visit": "^5.0.0",
-                "url-loader": "^4.1.1",
-                "vfile": "^6.0.1",
-                "webpack": "^5.88.1"
-              }
-            }
           }
         },
         "@docusaurus/plugin-content-pages": {
@@ -17786,39 +18115,6 @@
             "fs-extra": "^11.1.1",
             "tslib": "^2.6.0",
             "webpack": "^5.88.1"
-          },
-          "dependencies": {
-            "@docusaurus/mdx-loader": {
-              "version": "3.3.2",
-              "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.3.2.tgz",
-              "integrity": "sha512-AFRxj/aOk3/mfYDPxE3wTbrjeayVRvNSZP7mgMuUlrb2UlPRbSVAFX1k2RbgAJrnTSwMgb92m2BhJgYRfptN3g==",
-              "requires": {
-                "@docusaurus/logger": "3.3.2",
-                "@docusaurus/utils": "3.3.2",
-                "@docusaurus/utils-validation": "3.3.2",
-                "@mdx-js/mdx": "^3.0.0",
-                "@slorber/remark-comment": "^1.0.0",
-                "escape-html": "^1.0.3",
-                "estree-util-value-to-estree": "^3.0.1",
-                "file-loader": "^6.2.0",
-                "fs-extra": "^11.1.1",
-                "image-size": "^1.0.2",
-                "mdast-util-mdx": "^3.0.0",
-                "mdast-util-to-string": "^4.0.0",
-                "rehype-raw": "^7.0.0",
-                "remark-directive": "^3.0.0",
-                "remark-emoji": "^4.0.0",
-                "remark-frontmatter": "^5.0.0",
-                "remark-gfm": "^4.0.0",
-                "stringify-object": "^3.3.0",
-                "tslib": "^2.6.0",
-                "unified": "^11.0.3",
-                "unist-util-visit": "^5.0.0",
-                "url-loader": "^4.1.1",
-                "vfile": "^6.0.1",
-                "webpack": "^5.88.1"
-              }
-            }
           }
         },
         "@docusaurus/plugin-debug": {
@@ -17914,39 +18210,6 @@
             "rtlcss": "^4.1.0",
             "tslib": "^2.6.0",
             "utility-types": "^3.10.0"
-          },
-          "dependencies": {
-            "@docusaurus/mdx-loader": {
-              "version": "3.3.2",
-              "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.3.2.tgz",
-              "integrity": "sha512-AFRxj/aOk3/mfYDPxE3wTbrjeayVRvNSZP7mgMuUlrb2UlPRbSVAFX1k2RbgAJrnTSwMgb92m2BhJgYRfptN3g==",
-              "requires": {
-                "@docusaurus/logger": "3.3.2",
-                "@docusaurus/utils": "3.3.2",
-                "@docusaurus/utils-validation": "3.3.2",
-                "@mdx-js/mdx": "^3.0.0",
-                "@slorber/remark-comment": "^1.0.0",
-                "escape-html": "^1.0.3",
-                "estree-util-value-to-estree": "^3.0.1",
-                "file-loader": "^6.2.0",
-                "fs-extra": "^11.1.1",
-                "image-size": "^1.0.2",
-                "mdast-util-mdx": "^3.0.0",
-                "mdast-util-to-string": "^4.0.0",
-                "rehype-raw": "^7.0.0",
-                "remark-directive": "^3.0.0",
-                "remark-emoji": "^4.0.0",
-                "remark-frontmatter": "^5.0.0",
-                "remark-gfm": "^4.0.0",
-                "stringify-object": "^3.3.0",
-                "tslib": "^2.6.0",
-                "unified": "^11.0.3",
-                "unist-util-visit": "^5.0.0",
-                "url-loader": "^4.1.1",
-                "vfile": "^6.0.1",
-                "webpack": "^5.88.1"
-              }
-            }
           }
         },
         "@docusaurus/theme-common": {
@@ -17969,39 +18232,6 @@
             "prism-react-renderer": "^2.3.0",
             "tslib": "^2.6.0",
             "utility-types": "^3.10.0"
-          },
-          "dependencies": {
-            "@docusaurus/mdx-loader": {
-              "version": "3.3.2",
-              "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.3.2.tgz",
-              "integrity": "sha512-AFRxj/aOk3/mfYDPxE3wTbrjeayVRvNSZP7mgMuUlrb2UlPRbSVAFX1k2RbgAJrnTSwMgb92m2BhJgYRfptN3g==",
-              "requires": {
-                "@docusaurus/logger": "3.3.2",
-                "@docusaurus/utils": "3.3.2",
-                "@docusaurus/utils-validation": "3.3.2",
-                "@mdx-js/mdx": "^3.0.0",
-                "@slorber/remark-comment": "^1.0.0",
-                "escape-html": "^1.0.3",
-                "estree-util-value-to-estree": "^3.0.1",
-                "file-loader": "^6.2.0",
-                "fs-extra": "^11.1.1",
-                "image-size": "^1.0.2",
-                "mdast-util-mdx": "^3.0.0",
-                "mdast-util-to-string": "^4.0.0",
-                "rehype-raw": "^7.0.0",
-                "remark-directive": "^3.0.0",
-                "remark-emoji": "^4.0.0",
-                "remark-frontmatter": "^5.0.0",
-                "remark-gfm": "^4.0.0",
-                "stringify-object": "^3.3.0",
-                "tslib": "^2.6.0",
-                "unified": "^11.0.3",
-                "unist-util-visit": "^5.0.0",
-                "url-loader": "^4.1.1",
-                "vfile": "^6.0.1",
-                "webpack": "^5.88.1"
-              }
-            }
           }
         },
         "@docusaurus/theme-search-algolia": {
@@ -18068,6 +18298,70 @@
           "requires": {
             "@types/mdx": "^2.0.0"
           }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+        },
+        "html-minifier-terser": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
+          "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
+          "requires": {
+            "camel-case": "^4.1.2",
+            "clean-css": "~5.3.2",
+            "commander": "^10.0.0",
+            "entities": "^4.4.0",
+            "param-case": "^3.0.4",
+            "relateurl": "^0.2.7",
+            "terser": "^5.15.1"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "10.0.1",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+              "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
+            }
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },
@@ -18101,6 +18395,90 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
           "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
         }
+      }
+    },
+    "@docusaurus/utils": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.4.0.tgz",
+      "integrity": "sha512-fRwnu3L3nnWaXOgs88BVBmG1yGjcQqZNHG+vInhEa2Sz2oQB+ZjbEMO5Rh9ePFpZ0YDiDUhpaVjwmS+AU2F14g==",
+      "requires": {
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@svgr/webpack": "^8.1.0",
+        "escape-string-regexp": "^4.0.0",
+        "file-loader": "^6.2.0",
+        "fs-extra": "^11.1.1",
+        "github-slugger": "^1.5.0",
+        "globby": "^11.1.0",
+        "gray-matter": "^4.0.3",
+        "jiti": "^1.20.0",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "micromatch": "^4.0.5",
+        "prompts": "^2.4.2",
+        "resolve-pathname": "^3.0.0",
+        "shelljs": "^0.8.5",
+        "tslib": "^2.6.0",
+        "url-loader": "^4.1.1",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1"
+      },
+      "dependencies": {
+        "@docusaurus/logger": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.4.0.tgz",
+          "integrity": "sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==",
+          "requires": {
+            "chalk": "^4.1.2",
+            "tslib": "^2.6.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@docusaurus/utils-common": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.4.0.tgz",
+      "integrity": "sha512-NVx54Wr4rCEKsjOH5QEVvxIqVvm+9kh7q8aYTU5WzUU9/Hctd6aTrcZ3G0Id4zYJ+AeaG5K5qHA4CY5Kcm2iyQ==",
+      "requires": {
+        "tslib": "^2.6.0"
       }
     },
     "@docusaurus/utils-validation": {
@@ -19380,7 +19758,7 @@
     "@wethegit/corgi-docs": {
       "version": "file:docs",
       "requires": {
-        "@docusaurus/core": "~3.3.2",
+        "@docusaurus/core": "~3.4.0",
         "@docusaurus/module-type-aliases": "3.3.2",
         "@docusaurus/preset-classic": "~3.3.2",
         "@emotion/react": "~11.11.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "3.3.2"
+        "@docusaurus/module-type-aliases": "3.4.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -2631,11 +2631,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.3.2.tgz",
-      "integrity": "sha512-b/XB0TBJah5yKb4LYuJT4buFvL0MGAb0+vJDrJtlYMguRtsEBkf2nWl5xP7h4Dlw6ol0hsHrCYzJ50kNIOEclw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.4.0.tgz",
+      "integrity": "sha512-A1AyS8WF5Bkjnb8s+guTDuYmUiwJzNrtchebBHpc0gz0PyHJNMaybUlSrmJjHVcGrya0LKI4YcR3lBDQfXRYLw==",
+      "dev": true,
       "dependencies": {
-        "@docusaurus/types": "3.3.2",
+        "@docusaurus/types": "3.4.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2646,6 +2647,36 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/module-type-aliases/node_modules/@docusaurus/types": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.4.0.tgz",
+      "integrity": "sha512-4jcDO8kXi5Cf9TcyikB/yKmz14f2RZ2qTRerbHAsS+5InE9ZgSLBNLsewtFTcTOXSVcbU3FoGOzcNWAmU1TR0A==",
+      "dev": true,
+      "dependencies": {
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@docusaurus/module-type-aliases/node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@docusaurus/preset-classic": {
@@ -2810,6 +2841,24 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/module-type-aliases": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.3.2.tgz",
+      "integrity": "sha512-b/XB0TBJah5yKb4LYuJT4buFvL0MGAb0+vJDrJtlYMguRtsEBkf2nWl5xP7h4Dlw6ol0hsHrCYzJ50kNIOEclw==",
+      "dependencies": {
+        "@docusaurus/types": "3.3.2",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "@types/react-router-dom": "*",
+        "react-helmet-async": "*",
+        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-content-blog": {
@@ -17905,17 +17954,43 @@
       }
     },
     "@docusaurus/module-type-aliases": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.3.2.tgz",
-      "integrity": "sha512-b/XB0TBJah5yKb4LYuJT4buFvL0MGAb0+vJDrJtlYMguRtsEBkf2nWl5xP7h4Dlw6ol0hsHrCYzJ50kNIOEclw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.4.0.tgz",
+      "integrity": "sha512-A1AyS8WF5Bkjnb8s+guTDuYmUiwJzNrtchebBHpc0gz0PyHJNMaybUlSrmJjHVcGrya0LKI4YcR3lBDQfXRYLw==",
+      "dev": true,
       "requires": {
-        "@docusaurus/types": "3.3.2",
+        "@docusaurus/types": "3.4.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
         "@types/react-router-dom": "*",
         "react-helmet-async": "*",
         "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
+      },
+      "dependencies": {
+        "@docusaurus/types": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.4.0.tgz",
+          "integrity": "sha512-4jcDO8kXi5Cf9TcyikB/yKmz14f2RZ2qTRerbHAsS+5InE9ZgSLBNLsewtFTcTOXSVcbU3FoGOzcNWAmU1TR0A==",
+          "dev": true,
+          "requires": {
+            "@mdx-js/mdx": "^3.0.0",
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "commander": "^5.1.0",
+            "joi": "^17.9.2",
+            "react-helmet-async": "^1.3.0",
+            "utility-types": "^3.10.0",
+            "webpack": "^5.88.1",
+            "webpack-merge": "^5.9.0"
+          }
+        },
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+          "dev": true
+        }
       }
     },
     "@docusaurus/preset-classic": {
@@ -18053,6 +18128,20 @@
             "url-loader": "^4.1.1",
             "vfile": "^6.0.1",
             "webpack": "^5.88.1"
+          }
+        },
+        "@docusaurus/module-type-aliases": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.3.2.tgz",
+          "integrity": "sha512-b/XB0TBJah5yKb4LYuJT4buFvL0MGAb0+vJDrJtlYMguRtsEBkf2nWl5xP7h4Dlw6ol0hsHrCYzJ50kNIOEclw==",
+          "requires": {
+            "@docusaurus/types": "3.3.2",
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "@types/react-router-config": "*",
+            "@types/react-router-dom": "*",
+            "react-helmet-async": "*",
+            "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
           }
         },
         "@docusaurus/plugin-content-blog": {
@@ -19759,7 +19848,7 @@
       "version": "file:docs",
       "requires": {
         "@docusaurus/core": "~3.4.0",
-        "@docusaurus/module-type-aliases": "3.3.2",
+        "@docusaurus/module-type-aliases": "3.4.0",
         "@docusaurus/preset-classic": "~3.3.2",
         "@emotion/react": "~11.11.4",
         "@emotion/styled": "~11.11.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
       "version": "1.0.1",
       "dependencies": {
         "@docusaurus/core": "~3.4.0",
-        "@docusaurus/preset-classic": "~3.3.2",
+        "@docusaurus/preset-classic": "~3.4.0",
         "@emotion/react": "~11.11.4",
         "@emotion/styled": "~11.11.5",
         "@mdx-js/react": "^1.6.22",
@@ -2302,36 +2302,6 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/core/node_modules/@docusaurus/logger": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.4.0.tgz",
-      "integrity": "sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/core/node_modules/@docusaurus/utils-validation": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.4.0.tgz",
-      "integrity": "sha512-hYQ9fM+AXYVTWxJOT1EuNaRnrR2WGpRdLDQG07O8UOpsvCPWUVOeo26Rbm0JWY2sGLfzAb+tvJ62yF+8F+TV0g==",
-      "dependencies": {
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
     "node_modules/@docusaurus/core/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2439,9 +2409,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.3.2.tgz",
-      "integrity": "sha512-Ldu38GJ4P8g4guN7d7pyCOJ7qQugG7RVyaxrK8OnxuTlaImvQw33aDRwaX2eNmX8YK6v+//Z502F4sOZbHHCHQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.4.0.tgz",
+      "integrity": "sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.6.0"
@@ -2544,97 +2514,10 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/mdx-loader/node_modules/@docusaurus/logger": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.4.0.tgz",
-      "integrity": "sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/mdx-loader/node_modules/@docusaurus/utils-validation": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.4.0.tgz",
-      "integrity": "sha512-hYQ9fM+AXYVTWxJOT1EuNaRnrR2WGpRdLDQG07O8UOpsvCPWUVOeo26Rbm0JWY2sGLfzAb+tvJ62yF+8F+TV0g==",
-      "dependencies": {
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/mdx-loader/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/mdx-loader/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/mdx-loader/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@docusaurus/mdx-loader/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/@docusaurus/mdx-loader/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@docusaurus/module-type-aliases": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.4.0.tgz",
       "integrity": "sha512-A1AyS8WF5Bkjnb8s+guTDuYmUiwJzNrtchebBHpc0gz0PyHJNMaybUlSrmJjHVcGrya0LKI4YcR3lBDQfXRYLw==",
-      "dev": true,
       "dependencies": {
         "@docusaurus/types": "3.4.0",
         "@types/history": "^4.7.11",
@@ -2649,230 +2532,18 @@
         "react-dom": "*"
       }
     },
-    "node_modules/@docusaurus/module-type-aliases/node_modules/@docusaurus/types": {
+    "node_modules/@docusaurus/plugin-content-blog": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.4.0.tgz",
-      "integrity": "sha512-4jcDO8kXi5Cf9TcyikB/yKmz14f2RZ2qTRerbHAsS+5InE9ZgSLBNLsewtFTcTOXSVcbU3FoGOzcNWAmU1TR0A==",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.4.0.tgz",
+      "integrity": "sha512-vv6ZAj78ibR5Jh7XBUT4ndIjmlAxkijM3Sx5MAAzC1gyv0vupDQNhzuFg1USQmQVj3P5I6bquk12etPV3LJ+Xw==",
       "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/module-type-aliases/node_modules/commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.3.2.tgz",
-      "integrity": "sha512-1SDS7YIUN1Pg3BmD6TOTjhB7RSBHJRpgIRKx9TpxqyDrJ92sqtZhomDc6UYoMMLQNF2wHFZZVGFjxJhw2VpL+Q==",
-      "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/plugin-content-blog": "3.3.2",
-        "@docusaurus/plugin-content-docs": "3.3.2",
-        "@docusaurus/plugin-content-pages": "3.3.2",
-        "@docusaurus/plugin-debug": "3.3.2",
-        "@docusaurus/plugin-google-analytics": "3.3.2",
-        "@docusaurus/plugin-google-gtag": "3.3.2",
-        "@docusaurus/plugin-google-tag-manager": "3.3.2",
-        "@docusaurus/plugin-sitemap": "3.3.2",
-        "@docusaurus/theme-classic": "3.3.2",
-        "@docusaurus/theme-common": "3.3.2",
-        "@docusaurus/theme-search-algolia": "3.3.2",
-        "@docusaurus/types": "3.3.2"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/core": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.3.2.tgz",
-      "integrity": "sha512-PzKMydKI3IU1LmeZQDi+ut5RSuilbXnA8QdowGeJEgU8EJjmx3rBHNT1LxQxOVqNEwpWi/csLwd9bn7rUjggPA==",
-      "dependencies": {
-        "@babel/core": "^7.23.3",
-        "@babel/generator": "^7.23.3",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.22.9",
-        "@babel/preset-env": "^7.22.9",
-        "@babel/preset-react": "^7.22.5",
-        "@babel/preset-typescript": "^7.22.5",
-        "@babel/runtime": "^7.22.6",
-        "@babel/runtime-corejs3": "^7.22.6",
-        "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.3.2",
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
-        "autoprefixer": "^10.4.14",
-        "babel-loader": "^9.1.3",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.2",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.31.1",
-        "css-loader": "^6.8.1",
-        "css-minimizer-webpack-plugin": "^5.0.1",
-        "cssnano": "^6.1.2",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "html-minifier-terser": "^7.2.0",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.5.3",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.7.6",
-        "p-map": "^4.0.0",
-        "postcss": "^8.4.26",
-        "postcss-loader": "^7.3.3",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.5",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.9",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.88.1",
-        "webpack-bundle-analyzer": "^4.9.0",
-        "webpack-dev-server": "^4.15.1",
-        "webpack-merge": "^5.9.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.3.2.tgz",
-      "integrity": "sha512-+5+epLk/Rp4vFML4zmyTATNc3Is+buMAL6dNjrMWahdJCJlMWMPd/8YfU+2PA57t8mlSbhLJ7vAZVy54cd1vRQ==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "^8.4.38",
-        "postcss-sort-media-queries": "^5.2.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.3.2.tgz",
-      "integrity": "sha512-AFRxj/aOk3/mfYDPxE3wTbrjeayVRvNSZP7mgMuUlrb2UlPRbSVAFX1k2RbgAJrnTSwMgb92m2BhJgYRfptN3g==",
-      "dependencies": {
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.3.2.tgz",
-      "integrity": "sha512-b/XB0TBJah5yKb4LYuJT4buFvL0MGAb0+vJDrJtlYMguRtsEBkf2nWl5xP7h4Dlw6ol0hsHrCYzJ50kNIOEclw==",
-      "dependencies": {
-        "@docusaurus/types": "3.3.2",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "*",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.3.2.tgz",
-      "integrity": "sha512-fJU+dmqp231LnwDJv+BHVWft8pcUS2xVPZdeYH6/ibH1s2wQ/sLcmUrGWyIv/Gq9Ptj8XWjRPMghlxghuPPoxg==",
-      "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
@@ -2892,19 +2563,19 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.3.2.tgz",
-      "integrity": "sha512-Dm1ri2VlGATTN3VGk1ZRqdRXWa1UlFubjaEL6JaxaK7IIFqN/Esjpl+Xw10R33loHcRww/H76VdEeYayaL76eg==",
+    "node_modules/@docusaurus/plugin-content-docs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.4.0.tgz",
+      "integrity": "sha512-HkUCZffhBo7ocYheD9oZvMcDloRnGhBMOZRyVcAQRFmZPmNqSyISlXA1tQCIxW+r478fty97XXAGjNYzBjpCsg==",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/module-type-aliases": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/module-type-aliases": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -2922,16 +2593,16 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.3.2.tgz",
-      "integrity": "sha512-EKc9fQn5H2+OcGER8x1aR+7URtAGWySUgULfqE/M14+rIisdrBstuEZ4lUPDRrSIexOVClML82h2fDS+GSb8Ew==",
+    "node_modules/@docusaurus/plugin-content-pages": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.4.0.tgz",
+      "integrity": "sha512-h2+VN/0JjpR8fIkDEAoadNjfR3oLzB+v1qSXbIAKjQ46JAHx3X22n9nqS+BWSQnTnp1AjkjSvZyJMekmcwxzxg==",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -2944,14 +2615,14 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-debug": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.3.2.tgz",
-      "integrity": "sha512-oBIBmwtaB+YS0XlmZ3gCO+cMbsGvIYuAKkAopoCh0arVjtlyPbejzPrHuCoRHB9G7abjNZw7zoONOR8+8LM5+Q==",
+    "node_modules/@docusaurus/plugin-debug": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.4.0.tgz",
+      "integrity": "sha512-uV7FDUNXGyDSD3PwUaf5YijX91T5/H9SX4ErEcshzwgzWwBtK37nUWPU3ZLJfeTavX3fycTOqk9TglpOLaWkCg==",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^1.2.0",
         "tslib": "^2.6.0"
@@ -2964,14 +2635,14 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.3.2.tgz",
-      "integrity": "sha512-jXhrEIhYPSClMBK6/IA8qf1/FBoxqGXZvg7EuBax9HaK9+kL3L0TJIlatd8jQJOMtds8mKw806TOCc3rtEad1A==",
+    "node_modules/@docusaurus/plugin-google-analytics": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.4.0.tgz",
+      "integrity": "sha512-mCArluxEGi3cmYHqsgpGGt3IyLCrFBxPsxNZ56Mpur0xSlInnIHoeLDH7FvVVcPJRPSQ9/MfRqLsainRw+BojA==",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2982,14 +2653,14 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.3.2.tgz",
-      "integrity": "sha512-vcrKOHGbIDjVnNMrfbNpRQR1x6Jvcrb48kVzpBAOsKbj9rXZm/idjVAXRaewwobHdOrJkfWS/UJoxzK8wyLRBQ==",
+    "node_modules/@docusaurus/plugin-google-gtag": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.4.0.tgz",
+      "integrity": "sha512-Dsgg6PLAqzZw5wZ4QjUYc8Z2KqJqXxHxq3vIoyoBWiLEEfigIs7wHR+oiWUQy3Zk9MIk6JTYj7tMoQU0Jm3nqA==",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -3001,14 +2672,14 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.3.2.tgz",
-      "integrity": "sha512-ldkR58Fdeks0vC+HQ+L+bGFSJsotQsipXD+iKXQFvkOfmPIV6QbHRd7IIcm5b6UtwOiK33PylNS++gjyLUmaGw==",
+    "node_modules/@docusaurus/plugin-google-tag-manager": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.4.0.tgz",
+      "integrity": "sha512-O9tX1BTwxIhgXpOLpFDueYA9DWk69WCbDRrjYoMQtFHSkTyE7RhNgyjSPREUWJb9i+YUg3OrsvrBYRl64FCPCQ==",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3019,17 +2690,17 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.3.2.tgz",
-      "integrity": "sha512-/ZI1+bwZBhAgC30inBsHe3qY9LOZS+79fRGkNdTcGHRMcdAp6Vw2pCd1gzlxd/xU+HXsNP6cLmTOrggmRp3Ujg==",
+    "node_modules/@docusaurus/plugin-sitemap": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.4.0.tgz",
+      "integrity": "sha512-+0VDvx9SmNrFNgwPoeoCha+tRoAjopwT0+pYO1xAbyLcewXSemq+eLxEa46Q1/aoOaJQ0qqHELuQM7iS2gp33Q==",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -3042,23 +2713,50 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/theme-classic": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.3.2.tgz",
-      "integrity": "sha512-gepHFcsluIkPb4Im9ukkiO4lXrai671wzS3cKQkY9BXQgdVwsdPf/KS0Vs4Xlb0F10fTz+T3gNjkxNEgSN9M0A==",
+    "node_modules/@docusaurus/preset-classic": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.4.0.tgz",
+      "integrity": "sha512-Ohj6KB7siKqZaQhNJVMBBUzT3Nnp6eTKqO+FXO3qu/n1hJl3YLwVKTWBg28LF7MWrKu46UuYavwMRxud0VyqHg==",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/module-type-aliases": "3.3.2",
-        "@docusaurus/plugin-content-blog": "3.3.2",
-        "@docusaurus/plugin-content-docs": "3.3.2",
-        "@docusaurus/plugin-content-pages": "3.3.2",
-        "@docusaurus/theme-common": "3.3.2",
-        "@docusaurus/theme-translations": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/plugin-content-blog": "3.4.0",
+        "@docusaurus/plugin-content-docs": "3.4.0",
+        "@docusaurus/plugin-content-pages": "3.4.0",
+        "@docusaurus/plugin-debug": "3.4.0",
+        "@docusaurus/plugin-google-analytics": "3.4.0",
+        "@docusaurus/plugin-google-gtag": "3.4.0",
+        "@docusaurus/plugin-google-tag-manager": "3.4.0",
+        "@docusaurus/plugin-sitemap": "3.4.0",
+        "@docusaurus/theme-classic": "3.4.0",
+        "@docusaurus/theme-common": "3.4.0",
+        "@docusaurus/theme-search-algolia": "3.4.0",
+        "@docusaurus/types": "3.4.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-classic": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.4.0.tgz",
+      "integrity": "sha512-0IPtmxsBYv2adr1GnZRdMkEQt1YW6tpzrUPj02YxNpvJ5+ju4E13J5tB4nfdaen/tfR1hmpSPlTFPvTf4kwy8Q==",
+      "dependencies": {
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/module-type-aliases": "3.4.0",
+        "@docusaurus/plugin-content-blog": "3.4.0",
+        "@docusaurus/plugin-content-docs": "3.4.0",
+        "@docusaurus/plugin-content-pages": "3.4.0",
+        "@docusaurus/theme-common": "3.4.0",
+        "@docusaurus/theme-translations": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
@@ -3081,18 +2779,34 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/theme-common": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.3.2.tgz",
-      "integrity": "sha512-kXqSaL/sQqo4uAMQ4fHnvRZrH45Xz2OdJ3ABXDS7YVGPSDTBC8cLebFrRR4YF9EowUHto1UC/EIklJZQMG/usA==",
+    "node_modules/@docusaurus/theme-classic/node_modules/@mdx-js/react": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.0.1.tgz",
+      "integrity": "sha512-9ZrPIU4MGf6et1m1ov3zKf+q9+deetI51zprKB1D/z3NOb+rUxxtEl3mCjW5wTGh6VhRdwPueh1oRzi6ezkA8A==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/module-type-aliases": "3.3.2",
-        "@docusaurus/plugin-content-blog": "3.3.2",
-        "@docusaurus/plugin-content-docs": "3.3.2",
-        "@docusaurus/plugin-content-pages": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
+        "@types/mdx": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16",
+        "react": ">=16"
+      }
+    },
+    "node_modules/@docusaurus/theme-common": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.4.0.tgz",
+      "integrity": "sha512-0A27alXuv7ZdCg28oPE8nH/Iz73/IUejVaCazqu9elS4ypjiLhK3KfzdSQBnL/g7YfHSlymZKdiOHEo8fJ0qMA==",
+      "dependencies": {
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/module-type-aliases": "3.4.0",
+        "@docusaurus/plugin-content-blog": "3.4.0",
+        "@docusaurus/plugin-content-docs": "3.4.0",
+        "@docusaurus/plugin-content-pages": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -3110,19 +2824,19 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.3.2.tgz",
-      "integrity": "sha512-qLkfCl29VNBnF1MWiL9IyOQaHxUvicZp69hISyq/xMsNvFKHFOaOfk9xezYod2Q9xx3xxUh9t/QPigIei2tX4w==",
+    "node_modules/@docusaurus/theme-search-algolia": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.4.0.tgz",
+      "integrity": "sha512-aiHFx7OCw4Wck1z6IoShVdUWIjntC8FHCw9c5dR8r3q4Ynh+zkS8y2eFFunN/DL6RXPzpnvKCg3vhLQYJDmT9Q==",
       "dependencies": {
         "@docsearch/react": "^3.5.2",
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/plugin-content-docs": "3.3.2",
-        "@docusaurus/theme-common": "3.3.2",
-        "@docusaurus/theme-translations": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/plugin-content-docs": "3.4.0",
+        "@docusaurus/theme-common": "3.4.0",
+        "@docusaurus/theme-translations": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "algoliasearch": "^4.18.0",
         "algoliasearch-helper": "^3.13.3",
         "clsx": "^2.0.0",
@@ -3140,174 +2854,10 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/utils": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.3.2.tgz",
-      "integrity": "sha512-f4YMnBVymtkSxONv4Y8js3Gez9IgHX+Lcg6YRMOjVbq8sgCcdYK1lf6SObAuz5qB/mxiSK7tW0M9aaiIaUSUJg==",
-      "dependencies": {
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@svgr/webpack": "^8.1.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/utils-common": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.3.2.tgz",
-      "integrity": "sha512-QWFTLEkPYsejJsLStgtmetMFIA3pM8EPexcZ4WZ7b++gO5jGVH7zsipREnCHzk6+eDgeaXfkR6UPaTt86bp8Og==",
-      "dependencies": {
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@mdx-js/react": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.0.1.tgz",
-      "integrity": "sha512-9ZrPIU4MGf6et1m1ov3zKf+q9+deetI51zprKB1D/z3NOb+rUxxtEl3mCjW5wTGh6VhRdwPueh1oRzi6ezkA8A==",
-      "dependencies": {
-        "@types/mdx": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16",
-        "react": ">=16"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/html-minifier-terser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
-      "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "clean-css": "~5.3.2",
-        "commander": "^10.0.0",
-        "entities": "^4.4.0",
-        "param-case": "^3.0.4",
-        "relateurl": "^0.2.7",
-        "terser": "^5.15.1"
-      },
-      "bin": {
-        "html-minifier-terser": "cli.js"
-      },
-      "engines": {
-        "node": "^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/html-minifier-terser/node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.3.2.tgz",
-      "integrity": "sha512-bPuiUG7Z8sNpGuTdGnmKl/oIPeTwKr0AXLGu9KaP6+UFfRZiyWbWE87ti97RrevB2ffojEdvchNujparR3jEZQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.4.0.tgz",
+      "integrity": "sha512-zSxCSpmQCCdQU5Q4CnX/ID8CSUUI3fvmq4hU/GNP/XoAWtXo9SAVnM3TzpU8Gb//H3WCsT8mJcTfyOk3d9ftNg==",
       "dependencies": {
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -3317,9 +2867,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.3.2.tgz",
-      "integrity": "sha512-5p201S7AZhliRxTU7uMKtSsoC8mgPA9bs9b5NQg1IRdRxJfflursXNVsgc3PcMqiUTul/v1s3k3rXXFlRE890w==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.4.0.tgz",
+      "integrity": "sha512-4jcDO8kXi5Cf9TcyikB/yKmz14f2RZ2qTRerbHAsS+5InE9ZgSLBNLsewtFTcTOXSVcbU3FoGOzcNWAmU1TR0A==",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
         "@types/history": "^4.7.11",
@@ -3402,143 +2952,21 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.3.2.tgz",
-      "integrity": "sha512-itDgFs5+cbW9REuC7NdXals4V6++KifgVMzoGOOOSIifBQw+8ULhy86u5e1lnptVL0sv8oAjq2alO7I40GR7pA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.4.0.tgz",
+      "integrity": "sha512-hYQ9fM+AXYVTWxJOT1EuNaRnrR2WGpRdLDQG07O8UOpsvCPWUVOeo26Rbm0JWY2sGLfzAb+tvJ62yF+8F+TV0g==",
       "dependencies": {
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/utils-validation/node_modules/@docusaurus/utils": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.3.2.tgz",
-      "integrity": "sha512-f4YMnBVymtkSxONv4Y8js3Gez9IgHX+Lcg6YRMOjVbq8sgCcdYK1lf6SObAuz5qB/mxiSK7tW0M9aaiIaUSUJg==",
-      "dependencies": {
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@svgr/webpack": "^8.1.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/utils-validation/node_modules/@docusaurus/utils-common": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.3.2.tgz",
-      "integrity": "sha512-QWFTLEkPYsejJsLStgtmetMFIA3pM8EPexcZ4WZ7b++gO5jGVH7zsipREnCHzk6+eDgeaXfkR6UPaTt86bp8Og==",
-      "dependencies": {
         "tslib": "^2.6.0"
       },
       "engines": {
         "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/utils/node_modules/@docusaurus/logger": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.4.0.tgz",
-      "integrity": "sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/utils/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/utils/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/utils/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@docusaurus/utils/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/@docusaurus/utils/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -5368,9 +4796,9 @@
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.19.0.tgz",
-      "integrity": "sha512-AaSb5DZDMZmDQyIy6lf4aL0OZGgyIdqvLIIvSuVQOIOqfhrYSY7TvotIFI2x0Q3cP3xUpTd7lI1astUC4aXBJw==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.21.0.tgz",
+      "integrity": "sha512-hjVOrL15I3Y3K8xG0icwG1/tWE+MocqBrhW6uVBWpU+/kVEMK0BnM2xdssj6mZM61eJ4iRxHR0djEI3ENOpR8w==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -6166,17 +5594,6 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
         "entities": "^4.4.0"
-      }
-    },
-    "node_modules/cheerio/node_modules/parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-      "dependencies": {
-        "entities": "^4.4.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/chokidar": {
@@ -11939,6 +11356,17 @@
       "resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz",
       "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ=="
     },
+    "node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parse5-htmlparser2-tree-adapter": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
@@ -11963,17 +11391,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-      "dependencies": {
-        "entities": "^4.4.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -13595,17 +13012,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/rehype-raw/node_modules/parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-      "dependencies": {
-        "entities": "^4.4.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/rehype-raw/node_modules/property-information": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
@@ -14068,9 +13474,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sax": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
-      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -14130,9 +13536,9 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/search-insights": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.13.0.tgz",
-      "integrity": "sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.14.0.tgz",
+      "integrity": "sha512-OLN6MsPMCghDOqlCtsIsYgtsC0pnwVTyT9Mu6A3ewOj1DxvzZF6COrn2g86E/c05xbktB0XN04m/t1Z+n+fTGw==",
       "peer": true
     },
     "node_modules/section-matter": {
@@ -14471,9 +13877,9 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "node_modules/sitemap": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.1.tgz",
-      "integrity": "sha512-mK3aFtjz4VdJN0igpIJrinf3EO8U8mxOPsTBzSsy06UtjZQJ3YY3o3Xa7zSc5nMqcMrRwlChHZ18Kxg0caiPBg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.2.tgz",
+      "integrity": "sha512-ARCqzHJ0p4gWt+j7NlU5eDlIO9+Rkr/JhPFZKKQ1l5GCus7rJH4UdrlVAh0xC/gDS/Qir2UMxqYNHtsKr2rpCw==",
       "dependencies": {
         "@types/node": "^17.0.5",
         "@types/sax": "^1.2.1",
@@ -17708,30 +17114,6 @@
         "webpackbar": "^5.0.2"
       },
       "dependencies": {
-        "@docusaurus/logger": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.4.0.tgz",
-          "integrity": "sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==",
-          "requires": {
-            "chalk": "^4.1.2",
-            "tslib": "^2.6.0"
-          }
-        },
-        "@docusaurus/utils-validation": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.4.0.tgz",
-          "integrity": "sha512-hYQ9fM+AXYVTWxJOT1EuNaRnrR2WGpRdLDQG07O8UOpsvCPWUVOeo26Rbm0JWY2sGLfzAb+tvJ62yF+8F+TV0g==",
-          "requires": {
-            "@docusaurus/logger": "3.4.0",
-            "@docusaurus/utils": "3.4.0",
-            "@docusaurus/utils-common": "3.4.0",
-            "fs-extra": "^11.2.0",
-            "joi": "^17.9.2",
-            "js-yaml": "^4.1.0",
-            "lodash": "^4.17.21",
-            "tslib": "^2.6.0"
-          }
-        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -17810,9 +17192,9 @@
       }
     },
     "@docusaurus/logger": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.3.2.tgz",
-      "integrity": "sha512-Ldu38GJ4P8g4guN7d7pyCOJ7qQugG7RVyaxrK8OnxuTlaImvQw33aDRwaX2eNmX8YK6v+//Z502F4sOZbHHCHQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.4.0.tgz",
+      "integrity": "sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.6.0"
@@ -17887,77 +17269,12 @@
         "url-loader": "^4.1.1",
         "vfile": "^6.0.1",
         "webpack": "^5.88.1"
-      },
-      "dependencies": {
-        "@docusaurus/logger": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.4.0.tgz",
-          "integrity": "sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==",
-          "requires": {
-            "chalk": "^4.1.2",
-            "tslib": "^2.6.0"
-          }
-        },
-        "@docusaurus/utils-validation": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.4.0.tgz",
-          "integrity": "sha512-hYQ9fM+AXYVTWxJOT1EuNaRnrR2WGpRdLDQG07O8UOpsvCPWUVOeo26Rbm0JWY2sGLfzAb+tvJ62yF+8F+TV0g==",
-          "requires": {
-            "@docusaurus/logger": "3.4.0",
-            "@docusaurus/utils": "3.4.0",
-            "@docusaurus/utils-common": "3.4.0",
-            "fs-extra": "^11.2.0",
-            "joi": "^17.9.2",
-            "js-yaml": "^4.1.0",
-            "lodash": "^4.17.21",
-            "tslib": "^2.6.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "@docusaurus/module-type-aliases": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.4.0.tgz",
       "integrity": "sha512-A1AyS8WF5Bkjnb8s+guTDuYmUiwJzNrtchebBHpc0gz0PyHJNMaybUlSrmJjHVcGrya0LKI4YcR3lBDQfXRYLw==",
-      "dev": true,
       "requires": {
         "@docusaurus/types": "3.4.0",
         "@types/history": "^4.7.11",
@@ -17966,420 +17283,185 @@
         "@types/react-router-dom": "*",
         "react-helmet-async": "*",
         "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "dependencies": {
-        "@docusaurus/types": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.4.0.tgz",
-          "integrity": "sha512-4jcDO8kXi5Cf9TcyikB/yKmz14f2RZ2qTRerbHAsS+5InE9ZgSLBNLsewtFTcTOXSVcbU3FoGOzcNWAmU1TR0A==",
-          "dev": true,
-          "requires": {
-            "@mdx-js/mdx": "^3.0.0",
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "commander": "^5.1.0",
-            "joi": "^17.9.2",
-            "react-helmet-async": "^1.3.0",
-            "utility-types": "^3.10.0",
-            "webpack": "^5.88.1",
-            "webpack-merge": "^5.9.0"
-          }
-        },
-        "commander": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-          "dev": true
-        }
+      }
+    },
+    "@docusaurus/plugin-content-blog": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.4.0.tgz",
+      "integrity": "sha512-vv6ZAj78ibR5Jh7XBUT4ndIjmlAxkijM3Sx5MAAzC1gyv0vupDQNhzuFg1USQmQVj3P5I6bquk12etPV3LJ+Xw==",
+      "requires": {
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
+        "cheerio": "^1.0.0-rc.12",
+        "feed": "^4.2.2",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "reading-time": "^1.5.0",
+        "srcset": "^4.0.0",
+        "tslib": "^2.6.0",
+        "unist-util-visit": "^5.0.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1"
+      }
+    },
+    "@docusaurus/plugin-content-docs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.4.0.tgz",
+      "integrity": "sha512-HkUCZffhBo7ocYheD9oZvMcDloRnGhBMOZRyVcAQRFmZPmNqSyISlXA1tQCIxW+r478fty97XXAGjNYzBjpCsg==",
+      "requires": {
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/module-type-aliases": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
+        "@types/react-router-config": "^5.0.7",
+        "combine-promises": "^1.1.0",
+        "fs-extra": "^11.1.1",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1"
+      }
+    },
+    "@docusaurus/plugin-content-pages": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.4.0.tgz",
+      "integrity": "sha512-h2+VN/0JjpR8fIkDEAoadNjfR3oLzB+v1qSXbIAKjQ46JAHx3X22n9nqS+BWSQnTnp1AjkjSvZyJMekmcwxzxg==",
+      "requires": {
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
+        "fs-extra": "^11.1.1",
+        "tslib": "^2.6.0",
+        "webpack": "^5.88.1"
+      }
+    },
+    "@docusaurus/plugin-debug": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.4.0.tgz",
+      "integrity": "sha512-uV7FDUNXGyDSD3PwUaf5YijX91T5/H9SX4ErEcshzwgzWwBtK37nUWPU3ZLJfeTavX3fycTOqk9TglpOLaWkCg==",
+      "requires": {
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "fs-extra": "^11.1.1",
+        "react-json-view-lite": "^1.2.0",
+        "tslib": "^2.6.0"
+      }
+    },
+    "@docusaurus/plugin-google-analytics": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.4.0.tgz",
+      "integrity": "sha512-mCArluxEGi3cmYHqsgpGGt3IyLCrFBxPsxNZ56Mpur0xSlInnIHoeLDH7FvVVcPJRPSQ9/MfRqLsainRw+BojA==",
+      "requires": {
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
+        "tslib": "^2.6.0"
+      }
+    },
+    "@docusaurus/plugin-google-gtag": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.4.0.tgz",
+      "integrity": "sha512-Dsgg6PLAqzZw5wZ4QjUYc8Z2KqJqXxHxq3vIoyoBWiLEEfigIs7wHR+oiWUQy3Zk9MIk6JTYj7tMoQU0Jm3nqA==",
+      "requires": {
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
+        "@types/gtag.js": "^0.0.12",
+        "tslib": "^2.6.0"
+      }
+    },
+    "@docusaurus/plugin-google-tag-manager": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.4.0.tgz",
+      "integrity": "sha512-O9tX1BTwxIhgXpOLpFDueYA9DWk69WCbDRrjYoMQtFHSkTyE7RhNgyjSPREUWJb9i+YUg3OrsvrBYRl64FCPCQ==",
+      "requires": {
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
+        "tslib": "^2.6.0"
+      }
+    },
+    "@docusaurus/plugin-sitemap": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.4.0.tgz",
+      "integrity": "sha512-+0VDvx9SmNrFNgwPoeoCha+tRoAjopwT0+pYO1xAbyLcewXSemq+eLxEa46Q1/aoOaJQ0qqHELuQM7iS2gp33Q==",
+      "requires": {
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
+        "fs-extra": "^11.1.1",
+        "sitemap": "^7.1.1",
+        "tslib": "^2.6.0"
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.3.2.tgz",
-      "integrity": "sha512-1SDS7YIUN1Pg3BmD6TOTjhB7RSBHJRpgIRKx9TpxqyDrJ92sqtZhomDc6UYoMMLQNF2wHFZZVGFjxJhw2VpL+Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.4.0.tgz",
+      "integrity": "sha512-Ohj6KB7siKqZaQhNJVMBBUzT3Nnp6eTKqO+FXO3qu/n1hJl3YLwVKTWBg28LF7MWrKu46UuYavwMRxud0VyqHg==",
       "requires": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/plugin-content-blog": "3.3.2",
-        "@docusaurus/plugin-content-docs": "3.3.2",
-        "@docusaurus/plugin-content-pages": "3.3.2",
-        "@docusaurus/plugin-debug": "3.3.2",
-        "@docusaurus/plugin-google-analytics": "3.3.2",
-        "@docusaurus/plugin-google-gtag": "3.3.2",
-        "@docusaurus/plugin-google-tag-manager": "3.3.2",
-        "@docusaurus/plugin-sitemap": "3.3.2",
-        "@docusaurus/theme-classic": "3.3.2",
-        "@docusaurus/theme-common": "3.3.2",
-        "@docusaurus/theme-search-algolia": "3.3.2",
-        "@docusaurus/types": "3.3.2"
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/plugin-content-blog": "3.4.0",
+        "@docusaurus/plugin-content-docs": "3.4.0",
+        "@docusaurus/plugin-content-pages": "3.4.0",
+        "@docusaurus/plugin-debug": "3.4.0",
+        "@docusaurus/plugin-google-analytics": "3.4.0",
+        "@docusaurus/plugin-google-gtag": "3.4.0",
+        "@docusaurus/plugin-google-tag-manager": "3.4.0",
+        "@docusaurus/plugin-sitemap": "3.4.0",
+        "@docusaurus/theme-classic": "3.4.0",
+        "@docusaurus/theme-common": "3.4.0",
+        "@docusaurus/theme-search-algolia": "3.4.0",
+        "@docusaurus/types": "3.4.0"
+      }
+    },
+    "@docusaurus/theme-classic": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.4.0.tgz",
+      "integrity": "sha512-0IPtmxsBYv2adr1GnZRdMkEQt1YW6tpzrUPj02YxNpvJ5+ju4E13J5tB4nfdaen/tfR1hmpSPlTFPvTf4kwy8Q==",
+      "requires": {
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/module-type-aliases": "3.4.0",
+        "@docusaurus/plugin-content-blog": "3.4.0",
+        "@docusaurus/plugin-content-docs": "3.4.0",
+        "@docusaurus/plugin-content-pages": "3.4.0",
+        "@docusaurus/theme-common": "3.4.0",
+        "@docusaurus/theme-translations": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
+        "@mdx-js/react": "^3.0.0",
+        "clsx": "^2.0.0",
+        "copy-text-to-clipboard": "^3.2.0",
+        "infima": "0.2.0-alpha.43",
+        "lodash": "^4.17.21",
+        "nprogress": "^0.2.0",
+        "postcss": "^8.4.26",
+        "prism-react-renderer": "^2.3.0",
+        "prismjs": "^1.29.0",
+        "react-router-dom": "^5.3.4",
+        "rtlcss": "^4.1.0",
+        "tslib": "^2.6.0",
+        "utility-types": "^3.10.0"
       },
       "dependencies": {
-        "@docusaurus/core": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.3.2.tgz",
-          "integrity": "sha512-PzKMydKI3IU1LmeZQDi+ut5RSuilbXnA8QdowGeJEgU8EJjmx3rBHNT1LxQxOVqNEwpWi/csLwd9bn7rUjggPA==",
-          "requires": {
-            "@babel/core": "^7.23.3",
-            "@babel/generator": "^7.23.3",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-            "@babel/plugin-transform-runtime": "^7.22.9",
-            "@babel/preset-env": "^7.22.9",
-            "@babel/preset-react": "^7.22.5",
-            "@babel/preset-typescript": "^7.22.5",
-            "@babel/runtime": "^7.22.6",
-            "@babel/runtime-corejs3": "^7.22.6",
-            "@babel/traverse": "^7.22.8",
-            "@docusaurus/cssnano-preset": "3.3.2",
-            "@docusaurus/logger": "3.3.2",
-            "@docusaurus/mdx-loader": "3.3.2",
-            "@docusaurus/utils": "3.3.2",
-            "@docusaurus/utils-common": "3.3.2",
-            "@docusaurus/utils-validation": "3.3.2",
-            "autoprefixer": "^10.4.14",
-            "babel-loader": "^9.1.3",
-            "babel-plugin-dynamic-import-node": "^2.3.3",
-            "boxen": "^6.2.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.5.3",
-            "clean-css": "^5.3.2",
-            "cli-table3": "^0.6.3",
-            "combine-promises": "^1.1.0",
-            "commander": "^5.1.0",
-            "copy-webpack-plugin": "^11.0.0",
-            "core-js": "^3.31.1",
-            "css-loader": "^6.8.1",
-            "css-minimizer-webpack-plugin": "^5.0.1",
-            "cssnano": "^6.1.2",
-            "del": "^6.1.1",
-            "detect-port": "^1.5.1",
-            "escape-html": "^1.0.3",
-            "eta": "^2.2.0",
-            "eval": "^0.1.8",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^11.1.1",
-            "html-minifier-terser": "^7.2.0",
-            "html-tags": "^3.3.1",
-            "html-webpack-plugin": "^5.5.3",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.21",
-            "mini-css-extract-plugin": "^2.7.6",
-            "p-map": "^4.0.0",
-            "postcss": "^8.4.26",
-            "postcss-loader": "^7.3.3",
-            "prompts": "^2.4.2",
-            "react-dev-utils": "^12.0.1",
-            "react-helmet-async": "^1.3.0",
-            "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-            "react-router": "^5.3.4",
-            "react-router-config": "^5.1.1",
-            "react-router-dom": "^5.3.4",
-            "rtl-detect": "^1.0.4",
-            "semver": "^7.5.4",
-            "serve-handler": "^6.1.5",
-            "shelljs": "^0.8.5",
-            "terser-webpack-plugin": "^5.3.9",
-            "tslib": "^2.6.0",
-            "update-notifier": "^6.0.2",
-            "url-loader": "^4.1.1",
-            "webpack": "^5.88.1",
-            "webpack-bundle-analyzer": "^4.9.0",
-            "webpack-dev-server": "^4.15.1",
-            "webpack-merge": "^5.9.0",
-            "webpackbar": "^5.0.2"
-          }
-        },
-        "@docusaurus/cssnano-preset": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.3.2.tgz",
-          "integrity": "sha512-+5+epLk/Rp4vFML4zmyTATNc3Is+buMAL6dNjrMWahdJCJlMWMPd/8YfU+2PA57t8mlSbhLJ7vAZVy54cd1vRQ==",
-          "requires": {
-            "cssnano-preset-advanced": "^6.1.2",
-            "postcss": "^8.4.38",
-            "postcss-sort-media-queries": "^5.2.0",
-            "tslib": "^2.6.0"
-          }
-        },
-        "@docusaurus/mdx-loader": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.3.2.tgz",
-          "integrity": "sha512-AFRxj/aOk3/mfYDPxE3wTbrjeayVRvNSZP7mgMuUlrb2UlPRbSVAFX1k2RbgAJrnTSwMgb92m2BhJgYRfptN3g==",
-          "requires": {
-            "@docusaurus/logger": "3.3.2",
-            "@docusaurus/utils": "3.3.2",
-            "@docusaurus/utils-validation": "3.3.2",
-            "@mdx-js/mdx": "^3.0.0",
-            "@slorber/remark-comment": "^1.0.0",
-            "escape-html": "^1.0.3",
-            "estree-util-value-to-estree": "^3.0.1",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^11.1.1",
-            "image-size": "^1.0.2",
-            "mdast-util-mdx": "^3.0.0",
-            "mdast-util-to-string": "^4.0.0",
-            "rehype-raw": "^7.0.0",
-            "remark-directive": "^3.0.0",
-            "remark-emoji": "^4.0.0",
-            "remark-frontmatter": "^5.0.0",
-            "remark-gfm": "^4.0.0",
-            "stringify-object": "^3.3.0",
-            "tslib": "^2.6.0",
-            "unified": "^11.0.3",
-            "unist-util-visit": "^5.0.0",
-            "url-loader": "^4.1.1",
-            "vfile": "^6.0.1",
-            "webpack": "^5.88.1"
-          }
-        },
-        "@docusaurus/module-type-aliases": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.3.2.tgz",
-          "integrity": "sha512-b/XB0TBJah5yKb4LYuJT4buFvL0MGAb0+vJDrJtlYMguRtsEBkf2nWl5xP7h4Dlw6ol0hsHrCYzJ50kNIOEclw==",
-          "requires": {
-            "@docusaurus/types": "3.3.2",
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "@types/react-router-config": "*",
-            "@types/react-router-dom": "*",
-            "react-helmet-async": "*",
-            "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-          }
-        },
-        "@docusaurus/plugin-content-blog": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.3.2.tgz",
-          "integrity": "sha512-fJU+dmqp231LnwDJv+BHVWft8pcUS2xVPZdeYH6/ibH1s2wQ/sLcmUrGWyIv/Gq9Ptj8XWjRPMghlxghuPPoxg==",
-          "requires": {
-            "@docusaurus/core": "3.3.2",
-            "@docusaurus/logger": "3.3.2",
-            "@docusaurus/mdx-loader": "3.3.2",
-            "@docusaurus/types": "3.3.2",
-            "@docusaurus/utils": "3.3.2",
-            "@docusaurus/utils-common": "3.3.2",
-            "@docusaurus/utils-validation": "3.3.2",
-            "cheerio": "^1.0.0-rc.12",
-            "feed": "^4.2.2",
-            "fs-extra": "^11.1.1",
-            "lodash": "^4.17.21",
-            "reading-time": "^1.5.0",
-            "srcset": "^4.0.0",
-            "tslib": "^2.6.0",
-            "unist-util-visit": "^5.0.0",
-            "utility-types": "^3.10.0",
-            "webpack": "^5.88.1"
-          }
-        },
-        "@docusaurus/plugin-content-docs": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.3.2.tgz",
-          "integrity": "sha512-Dm1ri2VlGATTN3VGk1ZRqdRXWa1UlFubjaEL6JaxaK7IIFqN/Esjpl+Xw10R33loHcRww/H76VdEeYayaL76eg==",
-          "requires": {
-            "@docusaurus/core": "3.3.2",
-            "@docusaurus/logger": "3.3.2",
-            "@docusaurus/mdx-loader": "3.3.2",
-            "@docusaurus/module-type-aliases": "3.3.2",
-            "@docusaurus/types": "3.3.2",
-            "@docusaurus/utils": "3.3.2",
-            "@docusaurus/utils-common": "3.3.2",
-            "@docusaurus/utils-validation": "3.3.2",
-            "@types/react-router-config": "^5.0.7",
-            "combine-promises": "^1.1.0",
-            "fs-extra": "^11.1.1",
-            "js-yaml": "^4.1.0",
-            "lodash": "^4.17.21",
-            "tslib": "^2.6.0",
-            "utility-types": "^3.10.0",
-            "webpack": "^5.88.1"
-          }
-        },
-        "@docusaurus/plugin-content-pages": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.3.2.tgz",
-          "integrity": "sha512-EKc9fQn5H2+OcGER8x1aR+7URtAGWySUgULfqE/M14+rIisdrBstuEZ4lUPDRrSIexOVClML82h2fDS+GSb8Ew==",
-          "requires": {
-            "@docusaurus/core": "3.3.2",
-            "@docusaurus/mdx-loader": "3.3.2",
-            "@docusaurus/types": "3.3.2",
-            "@docusaurus/utils": "3.3.2",
-            "@docusaurus/utils-validation": "3.3.2",
-            "fs-extra": "^11.1.1",
-            "tslib": "^2.6.0",
-            "webpack": "^5.88.1"
-          }
-        },
-        "@docusaurus/plugin-debug": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.3.2.tgz",
-          "integrity": "sha512-oBIBmwtaB+YS0XlmZ3gCO+cMbsGvIYuAKkAopoCh0arVjtlyPbejzPrHuCoRHB9G7abjNZw7zoONOR8+8LM5+Q==",
-          "requires": {
-            "@docusaurus/core": "3.3.2",
-            "@docusaurus/types": "3.3.2",
-            "@docusaurus/utils": "3.3.2",
-            "fs-extra": "^11.1.1",
-            "react-json-view-lite": "^1.2.0",
-            "tslib": "^2.6.0"
-          }
-        },
-        "@docusaurus/plugin-google-analytics": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.3.2.tgz",
-          "integrity": "sha512-jXhrEIhYPSClMBK6/IA8qf1/FBoxqGXZvg7EuBax9HaK9+kL3L0TJIlatd8jQJOMtds8mKw806TOCc3rtEad1A==",
-          "requires": {
-            "@docusaurus/core": "3.3.2",
-            "@docusaurus/types": "3.3.2",
-            "@docusaurus/utils-validation": "3.3.2",
-            "tslib": "^2.6.0"
-          }
-        },
-        "@docusaurus/plugin-google-gtag": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.3.2.tgz",
-          "integrity": "sha512-vcrKOHGbIDjVnNMrfbNpRQR1x6Jvcrb48kVzpBAOsKbj9rXZm/idjVAXRaewwobHdOrJkfWS/UJoxzK8wyLRBQ==",
-          "requires": {
-            "@docusaurus/core": "3.3.2",
-            "@docusaurus/types": "3.3.2",
-            "@docusaurus/utils-validation": "3.3.2",
-            "@types/gtag.js": "^0.0.12",
-            "tslib": "^2.6.0"
-          }
-        },
-        "@docusaurus/plugin-google-tag-manager": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.3.2.tgz",
-          "integrity": "sha512-ldkR58Fdeks0vC+HQ+L+bGFSJsotQsipXD+iKXQFvkOfmPIV6QbHRd7IIcm5b6UtwOiK33PylNS++gjyLUmaGw==",
-          "requires": {
-            "@docusaurus/core": "3.3.2",
-            "@docusaurus/types": "3.3.2",
-            "@docusaurus/utils-validation": "3.3.2",
-            "tslib": "^2.6.0"
-          }
-        },
-        "@docusaurus/plugin-sitemap": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.3.2.tgz",
-          "integrity": "sha512-/ZI1+bwZBhAgC30inBsHe3qY9LOZS+79fRGkNdTcGHRMcdAp6Vw2pCd1gzlxd/xU+HXsNP6cLmTOrggmRp3Ujg==",
-          "requires": {
-            "@docusaurus/core": "3.3.2",
-            "@docusaurus/logger": "3.3.2",
-            "@docusaurus/types": "3.3.2",
-            "@docusaurus/utils": "3.3.2",
-            "@docusaurus/utils-common": "3.3.2",
-            "@docusaurus/utils-validation": "3.3.2",
-            "fs-extra": "^11.1.1",
-            "sitemap": "^7.1.1",
-            "tslib": "^2.6.0"
-          }
-        },
-        "@docusaurus/theme-classic": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.3.2.tgz",
-          "integrity": "sha512-gepHFcsluIkPb4Im9ukkiO4lXrai671wzS3cKQkY9BXQgdVwsdPf/KS0Vs4Xlb0F10fTz+T3gNjkxNEgSN9M0A==",
-          "requires": {
-            "@docusaurus/core": "3.3.2",
-            "@docusaurus/mdx-loader": "3.3.2",
-            "@docusaurus/module-type-aliases": "3.3.2",
-            "@docusaurus/plugin-content-blog": "3.3.2",
-            "@docusaurus/plugin-content-docs": "3.3.2",
-            "@docusaurus/plugin-content-pages": "3.3.2",
-            "@docusaurus/theme-common": "3.3.2",
-            "@docusaurus/theme-translations": "3.3.2",
-            "@docusaurus/types": "3.3.2",
-            "@docusaurus/utils": "3.3.2",
-            "@docusaurus/utils-common": "3.3.2",
-            "@docusaurus/utils-validation": "3.3.2",
-            "@mdx-js/react": "^3.0.0",
-            "clsx": "^2.0.0",
-            "copy-text-to-clipboard": "^3.2.0",
-            "infima": "0.2.0-alpha.43",
-            "lodash": "^4.17.21",
-            "nprogress": "^0.2.0",
-            "postcss": "^8.4.26",
-            "prism-react-renderer": "^2.3.0",
-            "prismjs": "^1.29.0",
-            "react-router-dom": "^5.3.4",
-            "rtlcss": "^4.1.0",
-            "tslib": "^2.6.0",
-            "utility-types": "^3.10.0"
-          }
-        },
-        "@docusaurus/theme-common": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.3.2.tgz",
-          "integrity": "sha512-kXqSaL/sQqo4uAMQ4fHnvRZrH45Xz2OdJ3ABXDS7YVGPSDTBC8cLebFrRR4YF9EowUHto1UC/EIklJZQMG/usA==",
-          "requires": {
-            "@docusaurus/mdx-loader": "3.3.2",
-            "@docusaurus/module-type-aliases": "3.3.2",
-            "@docusaurus/plugin-content-blog": "3.3.2",
-            "@docusaurus/plugin-content-docs": "3.3.2",
-            "@docusaurus/plugin-content-pages": "3.3.2",
-            "@docusaurus/utils": "3.3.2",
-            "@docusaurus/utils-common": "3.3.2",
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "@types/react-router-config": "*",
-            "clsx": "^2.0.0",
-            "parse-numeric-range": "^1.3.0",
-            "prism-react-renderer": "^2.3.0",
-            "tslib": "^2.6.0",
-            "utility-types": "^3.10.0"
-          }
-        },
-        "@docusaurus/theme-search-algolia": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.3.2.tgz",
-          "integrity": "sha512-qLkfCl29VNBnF1MWiL9IyOQaHxUvicZp69hISyq/xMsNvFKHFOaOfk9xezYod2Q9xx3xxUh9t/QPigIei2tX4w==",
-          "requires": {
-            "@docsearch/react": "^3.5.2",
-            "@docusaurus/core": "3.3.2",
-            "@docusaurus/logger": "3.3.2",
-            "@docusaurus/plugin-content-docs": "3.3.2",
-            "@docusaurus/theme-common": "3.3.2",
-            "@docusaurus/theme-translations": "3.3.2",
-            "@docusaurus/utils": "3.3.2",
-            "@docusaurus/utils-validation": "3.3.2",
-            "algoliasearch": "^4.18.0",
-            "algoliasearch-helper": "^3.13.3",
-            "clsx": "^2.0.0",
-            "eta": "^2.2.0",
-            "fs-extra": "^11.1.1",
-            "lodash": "^4.17.21",
-            "tslib": "^2.6.0",
-            "utility-types": "^3.10.0"
-          }
-        },
-        "@docusaurus/utils": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.3.2.tgz",
-          "integrity": "sha512-f4YMnBVymtkSxONv4Y8js3Gez9IgHX+Lcg6YRMOjVbq8sgCcdYK1lf6SObAuz5qB/mxiSK7tW0M9aaiIaUSUJg==",
-          "requires": {
-            "@docusaurus/logger": "3.3.2",
-            "@docusaurus/utils-common": "3.3.2",
-            "@svgr/webpack": "^8.1.0",
-            "escape-string-regexp": "^4.0.0",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^11.1.1",
-            "github-slugger": "^1.5.0",
-            "globby": "^11.1.0",
-            "gray-matter": "^4.0.3",
-            "jiti": "^1.20.0",
-            "js-yaml": "^4.1.0",
-            "lodash": "^4.17.21",
-            "micromatch": "^4.0.5",
-            "prompts": "^2.4.2",
-            "resolve-pathname": "^3.0.0",
-            "shelljs": "^0.8.5",
-            "tslib": "^2.6.0",
-            "url-loader": "^4.1.1",
-            "webpack": "^5.88.1"
-          }
-        },
-        "@docusaurus/utils-common": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.3.2.tgz",
-          "integrity": "sha512-QWFTLEkPYsejJsLStgtmetMFIA3pM8EPexcZ4WZ7b++gO5jGVH7zsipREnCHzk6+eDgeaXfkR6UPaTt86bp8Og==",
-          "requires": {
-            "tslib": "^2.6.0"
-          }
-        },
         "@mdx-js/react": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.0.1.tgz",
@@ -18387,86 +17469,67 @@
           "requires": {
             "@types/mdx": "^2.0.0"
           }
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "commander": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
-        },
-        "html-minifier-terser": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
-          "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
-          "requires": {
-            "camel-case": "^4.1.2",
-            "clean-css": "~5.3.2",
-            "commander": "^10.0.0",
-            "entities": "^4.4.0",
-            "param-case": "^3.0.4",
-            "relateurl": "^0.2.7",
-            "terser": "^5.15.1"
-          },
-          "dependencies": {
-            "commander": {
-              "version": "10.0.1",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-              "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
-            }
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         }
       }
     },
+    "@docusaurus/theme-common": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.4.0.tgz",
+      "integrity": "sha512-0A27alXuv7ZdCg28oPE8nH/Iz73/IUejVaCazqu9elS4ypjiLhK3KfzdSQBnL/g7YfHSlymZKdiOHEo8fJ0qMA==",
+      "requires": {
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/module-type-aliases": "3.4.0",
+        "@docusaurus/plugin-content-blog": "3.4.0",
+        "@docusaurus/plugin-content-docs": "3.4.0",
+        "@docusaurus/plugin-content-pages": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "clsx": "^2.0.0",
+        "parse-numeric-range": "^1.3.0",
+        "prism-react-renderer": "^2.3.0",
+        "tslib": "^2.6.0",
+        "utility-types": "^3.10.0"
+      }
+    },
+    "@docusaurus/theme-search-algolia": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.4.0.tgz",
+      "integrity": "sha512-aiHFx7OCw4Wck1z6IoShVdUWIjntC8FHCw9c5dR8r3q4Ynh+zkS8y2eFFunN/DL6RXPzpnvKCg3vhLQYJDmT9Q==",
+      "requires": {
+        "@docsearch/react": "^3.5.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/plugin-content-docs": "3.4.0",
+        "@docusaurus/theme-common": "3.4.0",
+        "@docusaurus/theme-translations": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
+        "algoliasearch": "^4.18.0",
+        "algoliasearch-helper": "^3.13.3",
+        "clsx": "^2.0.0",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0",
+        "utility-types": "^3.10.0"
+      }
+    },
     "@docusaurus/theme-translations": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.3.2.tgz",
-      "integrity": "sha512-bPuiUG7Z8sNpGuTdGnmKl/oIPeTwKr0AXLGu9KaP6+UFfRZiyWbWE87ti97RrevB2ffojEdvchNujparR3jEZQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.4.0.tgz",
+      "integrity": "sha512-zSxCSpmQCCdQU5Q4CnX/ID8CSUUI3fvmq4hU/GNP/XoAWtXo9SAVnM3TzpU8Gb//H3WCsT8mJcTfyOk3d9ftNg==",
       "requires": {
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
       }
     },
     "@docusaurus/types": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.3.2.tgz",
-      "integrity": "sha512-5p201S7AZhliRxTU7uMKtSsoC8mgPA9bs9b5NQg1IRdRxJfflursXNVsgc3PcMqiUTul/v1s3k3rXXFlRE890w==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.4.0.tgz",
+      "integrity": "sha512-4jcDO8kXi5Cf9TcyikB/yKmz14f2RZ2qTRerbHAsS+5InE9ZgSLBNLsewtFTcTOXSVcbU3FoGOzcNWAmU1TR0A==",
       "requires": {
         "@mdx-js/mdx": "^3.0.0",
         "@types/history": "^4.7.11",
@@ -18511,55 +17574,6 @@
         "url-loader": "^4.1.1",
         "utility-types": "^3.10.0",
         "webpack": "^5.88.1"
-      },
-      "dependencies": {
-        "@docusaurus/logger": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.4.0.tgz",
-          "integrity": "sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==",
-          "requires": {
-            "chalk": "^4.1.2",
-            "tslib": "^2.6.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "@docusaurus/utils-common": {
@@ -18571,52 +17585,18 @@
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.3.2.tgz",
-      "integrity": "sha512-itDgFs5+cbW9REuC7NdXals4V6++KifgVMzoGOOOSIifBQw+8ULhy86u5e1lnptVL0sv8oAjq2alO7I40GR7pA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.4.0.tgz",
+      "integrity": "sha512-hYQ9fM+AXYVTWxJOT1EuNaRnrR2WGpRdLDQG07O8UOpsvCPWUVOeo26Rbm0JWY2sGLfzAb+tvJ62yF+8F+TV0g==",
       "requires": {
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
         "tslib": "^2.6.0"
-      },
-      "dependencies": {
-        "@docusaurus/utils": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.3.2.tgz",
-          "integrity": "sha512-f4YMnBVymtkSxONv4Y8js3Gez9IgHX+Lcg6YRMOjVbq8sgCcdYK1lf6SObAuz5qB/mxiSK7tW0M9aaiIaUSUJg==",
-          "requires": {
-            "@docusaurus/logger": "3.3.2",
-            "@docusaurus/utils-common": "3.3.2",
-            "@svgr/webpack": "^8.1.0",
-            "escape-string-regexp": "^4.0.0",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^11.1.1",
-            "github-slugger": "^1.5.0",
-            "globby": "^11.1.0",
-            "gray-matter": "^4.0.3",
-            "jiti": "^1.20.0",
-            "js-yaml": "^4.1.0",
-            "lodash": "^4.17.21",
-            "micromatch": "^4.0.5",
-            "prompts": "^2.4.2",
-            "resolve-pathname": "^3.0.0",
-            "shelljs": "^0.8.5",
-            "tslib": "^2.6.0",
-            "url-loader": "^4.1.1",
-            "webpack": "^5.88.1"
-          }
-        },
-        "@docusaurus/utils-common": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.3.2.tgz",
-          "integrity": "sha512-QWFTLEkPYsejJsLStgtmetMFIA3pM8EPexcZ4WZ7b++gO5jGVH7zsipREnCHzk6+eDgeaXfkR6UPaTt86bp8Og==",
-          "requires": {
-            "tslib": "^2.6.0"
-          }
-        }
       }
     },
     "@emotion/babel-plugin": {
@@ -19849,7 +18829,7 @@
       "requires": {
         "@docusaurus/core": "~3.4.0",
         "@docusaurus/module-type-aliases": "3.4.0",
-        "@docusaurus/preset-classic": "~3.3.2",
+        "@docusaurus/preset-classic": "~3.4.0",
         "@emotion/react": "~11.11.4",
         "@emotion/styled": "~11.11.5",
         "@mdx-js/react": "^1.6.22",
@@ -19996,9 +18976,9 @@
       }
     },
     "algoliasearch-helper": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.19.0.tgz",
-      "integrity": "sha512-AaSb5DZDMZmDQyIy6lf4aL0OZGgyIdqvLIIvSuVQOIOqfhrYSY7TvotIFI2x0Q3cP3xUpTd7lI1astUC4aXBJw==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.21.0.tgz",
+      "integrity": "sha512-hjVOrL15I3Y3K8xG0icwG1/tWE+MocqBrhW6uVBWpU+/kVEMK0BnM2xdssj6mZM61eJ4iRxHR0djEI3ENOpR8w==",
       "requires": {
         "@algolia/events": "^4.0.1"
       }
@@ -20493,14 +19473,6 @@
             "domelementtype": "^2.3.0",
             "domhandler": "^5.0.3",
             "domutils": "^3.0.1",
-            "entities": "^4.4.0"
-          }
-        },
-        "parse5": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-          "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-          "requires": {
             "entities": "^4.4.0"
           }
         }
@@ -24557,6 +23529,14 @@
       "resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz",
       "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ=="
     },
+    "parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "requires": {
+        "entities": "^4.4.0"
+      }
+    },
     "parse5-htmlparser2-tree-adapter": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
@@ -24572,14 +23552,6 @@
           "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
           "requires": {
             "domelementtype": "^2.3.0"
-          }
-        },
-        "parse5": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-          "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-          "requires": {
-            "entities": "^4.4.0"
           }
         }
       }
@@ -25695,14 +24667,6 @@
             "vfile": "^6.0.0"
           }
         },
-        "parse5": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-          "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-          "requires": {
-            "entities": "^4.4.0"
-          }
-        },
         "property-information": {
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
@@ -26024,9 +24988,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sax": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
-      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
     },
     "scheduler": {
       "version": "0.23.2",
@@ -26074,9 +25038,9 @@
       }
     },
     "search-insights": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.13.0.tgz",
-      "integrity": "sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.14.0.tgz",
+      "integrity": "sha512-OLN6MsPMCghDOqlCtsIsYgtsC0pnwVTyT9Mu6A3ewOj1DxvzZF6COrn2g86E/c05xbktB0XN04m/t1Z+n+fTGw==",
       "peer": true
     },
     "section-matter": {
@@ -26354,9 +25318,9 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "sitemap": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.1.tgz",
-      "integrity": "sha512-mK3aFtjz4VdJN0igpIJrinf3EO8U8mxOPsTBzSsy06UtjZQJ3YY3o3Xa7zSc5nMqcMrRwlChHZ18Kxg0caiPBg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.2.tgz",
+      "integrity": "sha512-ARCqzHJ0p4gWt+j7NlU5eDlIO9+Rkr/JhPFZKKQ1l5GCus7rJH4UdrlVAh0xC/gDS/Qir2UMxqYNHtsKr2rpCw==",
       "requires": {
         "@types/node": "^17.0.5",
         "@types/sax": "^1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@mui/icons-material": "~5.15.18",
         "clsx": "^2.1.1",
         "prism-react-renderer": "^2.3.1",
-        "react": "^17.0.2",
+        "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
@@ -48,18 +48,6 @@
       },
       "engines": {
         "node": ">=16.14"
-      }
-    },
-    "docs/node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -12706,7 +12694,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -19402,19 +19389,8 @@
         "@mui/icons-material": "~5.15.18",
         "clsx": "^2.1.1",
         "prism-react-renderer": "^2.3.1",
-        "react": "^17.0.2",
+        "react": "^18.3.1",
         "react-dom": "^18.3.1"
-      },
-      "dependencies": {
-        "react": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-          "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
       }
     },
     "@xtuc/ieee754": {
@@ -24781,7 +24757,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }


### PR DESCRIPTION
## Description
- Upgrades the base corgi template to use `v3.0.1` of `@wethegit/react-hooks`.
- Includes a couple dependabot updates which are already in `main`.

### Notes 
This has potential to be a breaking change for anyone expecting the API from v2.x of the hooks library, so I'm requesting to merge this into our upcoming major release