### PR TITLE
[Project template] Bugfix: Introduce fallbacks for core node modules in browser

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/corgi",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Command line interface for use with the corgi framework.",
   "main": "bin/index.js",
   "bin": {

--- a/cli/templates/project/next.config.js
+++ b/cli/templates/project/next.config.js
@@ -1,5 +1,6 @@
-const path = require("path")
+const path = require("node:path")
 
+const webpack = require("webpack")
 const withPlugins = require("next-compose-plugins")
 const yaml = require("next-plugin-yaml")
 
@@ -25,10 +26,19 @@ const nextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
+      "~/*": resolve("./*"),
       "@local/*": resolve("src/*"),
     }
 
-    config.resolve.fallback = { fs: false }
+    // This fixes and issue with Webpack 5 no longer polyfilling node core modules for the browser.
+    config.resolve.fallback = {
+      fs: false,
+    }
+    config.plugins.push(
+      new webpack.NormalModuleReplacementPlugin(/^node:/, (resource) => {
+        resource.request = resource.request.replace(/^node:/, "")
+      })
+    )
 
     // insert js-yaml-loader
     config.module.rules.push({

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
     },
     "cli": {
       "name": "@wethegit/corgi",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "~5.3.0",


### PR DESCRIPTION
## Overview
Time tracking: https://wethecollective.teamwork.com/app/tasks/25651481

This fixes an issue that was introduced with Next 14 due to its use of Webpack 5. Webpack no longer polyfills core Node.js modules ("fs" for example), so it became necessary to do this manually. [Reference](https://webpack.js.org/configuration/resolve/#resolvefallback). This was build-breaking, and rendered Corgi unusable.

## Does this fix any existing issues?
Fixes #201 

## Additional notes
This bumps the corgi CLI to `4.0.2`